### PR TITLE
Check for escapeQuotes when deserialising files

### DIFF
--- a/src/main/java/com/crowdin/client/core/http/impl/json/FileExportOptionsDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/FileExportOptionsDeserializer.java
@@ -30,7 +30,7 @@ public class FileExportOptionsDeserializer extends JsonDeserializer<ExportOption
         List<String> fields = StreamSupport
                 .stream(iterable.spliterator(), false)
                 .collect(Collectors.toList());
-        if (fields.contains("escapeSpecialCharacters")) {
+        if (fields.contains("escapeSpecialCharacters") || fields.contains("escapeQuotes")) {
             return this.objectMapper.readValue(treeNode.toString(), PropertyFileExportOptions.class);
         } else {
             return this.objectMapper.readValue(treeNode.toString(), GeneralFileExportOptions.class);

--- a/src/test/java/com/crowdin/client/sourcefiles/SourceFilesApiTest.java
+++ b/src/test/java/com/crowdin/client/sourcefiles/SourceFilesApiTest.java
@@ -12,8 +12,10 @@ import com.crowdin.client.sourcefiles.model.AddDirectoryRequest;
 import com.crowdin.client.sourcefiles.model.AddFileRequest;
 import com.crowdin.client.sourcefiles.model.Branch;
 import com.crowdin.client.sourcefiles.model.Directory;
+import com.crowdin.client.sourcefiles.model.ExportOptions;
 import com.crowdin.client.sourcefiles.model.File;
 import com.crowdin.client.sourcefiles.model.FileRevision;
+import com.crowdin.client.sourcefiles.model.GeneralFileExportOptions;
 import com.crowdin.client.sourcefiles.model.PropertyFileExportOptions;
 import com.crowdin.client.sourcefiles.model.SpreadsheetFileImportOptions;
 import com.crowdin.client.sourcefiles.model.UpdateFileRequest;
@@ -31,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SourceFilesApiTest extends TestClient {
 
@@ -153,9 +156,28 @@ public class SourceFilesApiTest extends TestClient {
     @Test
     public void listFilesTest() {
         ResponseList<File> fileResponseList = this.getSourceFilesApi().listFiles(projectId, null, null, null, null, null);
-        assertEquals(fileResponseList.getData().size(), 1);
+        assertEquals(fileResponseList.getData().size(), 3);
         assertEquals(fileResponseList.getData().get(0).getData().getId(), fileId);
         assertEquals(fileResponseList.getData().get(0).getData().getName(), fileName);
+        ExportOptions exportOptions = fileResponseList.getData().get(0).getData().getExportOptions();
+        assertTrue(exportOptions instanceof GeneralFileExportOptions);
+        assertEquals(((GeneralFileExportOptions) exportOptions).getExportPattern(), "/localization/%locale%/%file_name%.%file_extension%");
+
+        assertEquals(fileResponseList.getData().get(1).getData().getId(), Long.valueOf(45L));
+        assertEquals(fileResponseList.getData().get(1).getData().getName(), "fileA.properties");
+        exportOptions = fileResponseList.getData().get(1).getData().getExportOptions();
+        assertTrue(exportOptions instanceof PropertyFileExportOptions);
+        assertEquals(((PropertyFileExportOptions) exportOptions).getExportPattern(), "/files/fileA.properties");
+        assertEquals(((PropertyFileExportOptions) exportOptions).getEscapeQuotes(), Integer.valueOf(3));
+        assertEquals(((PropertyFileExportOptions) exportOptions).getEscapeSpecialCharacters(), null);
+
+        assertEquals(fileResponseList.getData().get(2).getData().getId(), Long.valueOf(46L));
+        assertEquals(fileResponseList.getData().get(2).getData().getName(), "fileB.properties");
+        exportOptions = fileResponseList.getData().get(2).getData().getExportOptions();
+        assertTrue(exportOptions instanceof PropertyFileExportOptions);
+        assertEquals(((PropertyFileExportOptions) exportOptions).getExportPattern(), "/files/fileB.properties");
+        assertEquals(((PropertyFileExportOptions) exportOptions).getEscapeQuotes(), null);
+        assertEquals(((PropertyFileExportOptions) exportOptions).getEscapeSpecialCharacters(), Integer.valueOf(1));
     }
 
     @Test

--- a/src/test/resources/api/sourcefiles/listFiles.json
+++ b/src/test/resources/api/sourcefiles/listFiles.json
@@ -28,6 +28,48 @@
         "createdAt": "2019-09-19T15:10:43+00:00",
         "updatedAt": "2019-09-19T15:10:46+00:00"
       }
+    },
+    {
+      "data": {
+        "id": 45,
+        "projectId": 2,
+        "branchId": 34,
+        "directoryId": 4,
+        "name": "fileA.properties",
+        "title": "File A",
+        "type": "properties",
+        "revisionId": 1,
+        "status": "active",
+        "priority": "normal",
+        "importOptions": {},
+        "exportOptions": {
+          "escapeQuotes": 3,
+          "exportPattern": "/files/fileA.properties"
+        },
+        "createdAt": "2019-09-19T15:10:43+00:00",
+        "updatedAt": "2019-09-19T15:10:46+00:00"
+      }
+    },
+    {
+      "data": {
+        "id": 46,
+        "projectId": 2,
+        "branchId": 34,
+        "directoryId": 4,
+        "name": "fileB.properties",
+        "title": "File B",
+        "type": "properties",
+        "revisionId": 1,
+        "status": "active",
+        "priority": "normal",
+        "importOptions": {},
+        "exportOptions": {
+          "escapeSpecialCharacters": 1,
+          "exportPattern": "/files/fileB.properties"
+        },
+        "createdAt": "2019-09-19T15:10:43+00:00",
+        "updatedAt": "2019-09-19T15:10:46+00:00"
+      }
     }
   ],
   "pagination": {


### PR DESCRIPTION
Otherwise it would fail to deserialise the file contents by using the
incorrect export options class (`GeneralFileExportOptions` instead of
`PropertyFileExportOptions`).