### PR TITLE
Add non-enterprise options to BuildProjectTranslationRequest

### DIFF
--- a/src/main/java/com/crowdin/client/translations/model/BuildProjectTranslationRequest.java
+++ b/src/main/java/com/crowdin/client/translations/model/BuildProjectTranslationRequest.java
@@ -1,12 +1,4 @@
 package com.crowdin.client.translations.model;
 
-import lombok.Data;
-
-import java.util.List;
-
-@Data
-public class BuildProjectTranslationRequest {
-
-    private Long branchId;
-    private List<String> targetLanguageIds;
+public interface BuildProjectTranslationRequest {
 }

--- a/src/main/java/com/crowdin/client/translations/model/CharTransformation.java
+++ b/src/main/java/com/crowdin/client/translations/model/CharTransformation.java
@@ -1,0 +1,27 @@
+package com.crowdin.client.translations.model;
+
+import com.crowdin.client.core.model.EnumConverter;
+
+public enum CharTransformation implements EnumConverter<CharTransformation> {
+    ASIAN("asian"), CYRILLIC("cyrillic"), EUROPEAN("european"), ARABIC("arabic");
+
+    private final String value;
+
+    CharTransformation(String value) {
+        this.value = value;
+    }
+
+    public static CharTransformation from(String value) {
+        for (CharTransformation m : CharTransformation.values()) {
+            if (m.value.equals(value)) {
+                return m;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String to(CharTransformation v) {
+        return v.value;
+    }
+}

--- a/src/main/java/com/crowdin/client/translations/model/CrowdinTranslationCraeteProjectPseudoBuildForm.java
+++ b/src/main/java/com/crowdin/client/translations/model/CrowdinTranslationCraeteProjectPseudoBuildForm.java
@@ -1,0 +1,13 @@
+package com.crowdin.client.translations.model;
+
+import lombok.Data;
+
+@Data
+public class CrowdinTranslationCraeteProjectPseudoBuildForm implements BuildProjectTranslationRequest {
+
+    private Boolean pseudo;
+    private String prefix;
+    private String suffix;
+    private Integer lengthTransformation;
+    private CharTransformation charTransformation;
+}

--- a/src/main/java/com/crowdin/client/translations/model/CrowdinTranslationCreateProjectBuildForm.java
+++ b/src/main/java/com/crowdin/client/translations/model/CrowdinTranslationCreateProjectBuildForm.java
@@ -1,0 +1,16 @@
+package com.crowdin.client.translations.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class CrowdinTranslationCreateProjectBuildForm implements BuildProjectTranslationRequest {
+
+    private Long branchId;
+    private List<String> targetLanguageIds;
+    private Boolean exportTranslatedOnly;
+    private Boolean skipUntranslatedFiles;
+    private Boolean exportApprovedOnly;
+
+}

--- a/src/test/java/com/crowdin/client/translations/TranslationsApiTest.java
+++ b/src/test/java/com/crowdin/client/translations/TranslationsApiTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class TranslationsApiTest extends TestClient {
 
     private final Long projectId = 12L;
+    private final Long parallelProjectId = 13L;
     private final String language = "uk";
     private final String preTranslationId = "9e7de270-4f83-41cb-b606-2f90631f26e2";
     private final Long fileId = 2L;
@@ -35,6 +36,7 @@ public class TranslationsApiTest extends TestClient {
                 RequestMock.build(this.url + "/projects/" + projectId + "/translations/builds/files/" + fileId, HttpPost.METHOD_NAME, "api/translations/buildFileRequest.json", "api/translations/downloadLink.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/translations/builds", HttpGet.METHOD_NAME, "api/translations/listProjectBuilds.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/translations/builds", HttpPost.METHOD_NAME, "api/translations/buildProjectRequest.json", "api/translations/projectBuildStatus.json"),
+                RequestMock.build(this.url + "/projects/" + parallelProjectId + "/translations/builds", HttpPost.METHOD_NAME, "api/translations/pseudoBuildProjectRequest.json", "api/translations/projectBuildStatus.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/translations/" + language, HttpPost.METHOD_NAME, "api/translations/uploadTranslationRequest.json", "api/translations/uploadTranslationResponse.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/translations/builds/" + buildId + "/download", HttpGet.METHOD_NAME, "api/translations/downloadLink.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/translations/builds/" + buildId, HttpGet.METHOD_NAME, "api/translations/projectBuildStatus.json"),
@@ -79,6 +81,18 @@ public class TranslationsApiTest extends TestClient {
         CrowdinTranslationCreateProjectBuildForm request = new CrowdinTranslationCreateProjectBuildForm();
         request.setTargetLanguageIds(singletonList(language));
         ResponseObject<ProjectBuild> projectBuildResponseObject = this.getTranslationsApi().buildProjectTranslation(projectId, request);
+        assertEquals(projectBuildResponseObject.getData().getId(), buildId);
+    }
+
+    @Test
+    public void pseudoBuildProjectTranslationTest() {
+        CrowdinTranslationCraeteProjectPseudoBuildForm request = new CrowdinTranslationCraeteProjectPseudoBuildForm();
+        request.setPseudo(true);
+        request.setPrefix("pre");
+        request.setSuffix("ion");
+        request.setLengthTransformation(0);
+        request.setCharTransformation(CharTransformation.ASIAN);
+        ResponseObject<ProjectBuild> projectBuildResponseObject = this.getTranslationsApi().buildProjectTranslation(parallelProjectId, request);
         assertEquals(projectBuildResponseObject.getData().getId(), buildId);
     }
 

--- a/src/test/java/com/crowdin/client/translations/TranslationsApiTest.java
+++ b/src/test/java/com/crowdin/client/translations/TranslationsApiTest.java
@@ -5,15 +5,7 @@ import com.crowdin.client.core.model.ResponseList;
 import com.crowdin.client.core.model.ResponseObject;
 import com.crowdin.client.framework.RequestMock;
 import com.crowdin.client.framework.TestClient;
-import com.crowdin.client.translations.model.ApplyPreTranslationRequest;
-import com.crowdin.client.translations.model.AutoApproveOption;
-import com.crowdin.client.translations.model.BuildProjectFileTranslationRequest;
-import com.crowdin.client.translations.model.BuildProjectTranslationRequest;
-import com.crowdin.client.translations.model.Method;
-import com.crowdin.client.translations.model.PreTranslationStatus;
-import com.crowdin.client.translations.model.ProjectBuild;
-import com.crowdin.client.translations.model.UploadTranslationsRequest;
-import com.crowdin.client.translations.model.UploadTranslationsResponse;
+import com.crowdin.client.translations.model.*;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
@@ -84,7 +76,7 @@ public class TranslationsApiTest extends TestClient {
 
     @Test
     public void buildProjectTranslationTest() {
-        BuildProjectTranslationRequest request = new BuildProjectTranslationRequest();
+        CrowdinTranslationCreateProjectBuildForm request = new CrowdinTranslationCreateProjectBuildForm();
         request.setTargetLanguageIds(singletonList(language));
         ResponseObject<ProjectBuild> projectBuildResponseObject = this.getTranslationsApi().buildProjectTranslation(projectId, request);
         assertEquals(projectBuildResponseObject.getData().getId(), buildId);

--- a/src/test/resources/api/translations/pseudoBuildProjectRequest.json
+++ b/src/test/resources/api/translations/pseudoBuildProjectRequest.json
@@ -1,0 +1,7 @@
+{
+  "pseudo": true,
+  "prefix": "pre",
+  "suffix": "ion",
+  "lengthTransformation": 0,
+  "charTransformation": "asian"
+}


### PR DESCRIPTION
Add missing options from [Build Project Translations](https://support.crowdin.com/api/v2/#tag/Translations/paths/~1projects~1{projectId}~1translations~1builds/post)
(API for enterprise [here](https://support.crowdin.com/enterprise/api/#operation/api.projects.translations.builds.post))