### PR TITLE
CrowdinVendorManualTaskCreateForm Support - Tasks Post API

### DIFF
--- a/src/main/java/com/crowdin/client/tasks/model/CrowdinVendorManualTaskCreateFormRequest.java
+++ b/src/main/java/com/crowdin/client/tasks/model/CrowdinVendorManualTaskCreateFormRequest.java
@@ -1,0 +1,25 @@
+package com.crowdin.client.tasks.model;
+
+import lombok.Data;
+
+import java.util.Date;
+import java.util.List;
+
+@Data
+public class CrowdinVendorManualTaskCreateFormRequest extends AddTaskRequest {
+
+    private String title;
+    private String languageId;
+    private List<Long> fileIds;
+    private Integer type;
+    private String vendor;
+    private Status status;
+    private String description;
+    private Boolean skipAssignedStrings;
+    private Boolean skipUntranslatedStrings;
+    private List<Long> labelIds;
+    private List<AssigneeRequest> assignees;
+    private Date deadline;
+    private Date dateFrom;
+    private Date dateTo;
+}


### PR DESCRIPTION
- Added Request Body Schema extending the `AddTaskRequest` class to provide the support for `CrowdinVendorManualTaskCreateForm`

- Resolves #107 