### PR TITLE
spelling: create [API]

### DIFF
--- a/src/main/java/com/crowdin/client/translations/model/CrowdinTranslationCreateProjectPseudoBuildForm.java
+++ b/src/main/java/com/crowdin/client/translations/model/CrowdinTranslationCreateProjectPseudoBuildForm.java
@@ -2,9 +2,8 @@ package com.crowdin.client.translations.model;
 
 import lombok.Data;
 
-@Deprecated
 @Data
-public class CrowdinTranslationCraeteProjectPseudoBuildForm implements BuildProjectTranslationRequest {
+public class CrowdinTranslationCreateProjectPseudoBuildForm implements BuildProjectTranslationRequest {
 
     private Long branchId;
     private Boolean pseudo;

--- a/src/test/java/com/crowdin/client/translations/TranslationsApiTest.java
+++ b/src/test/java/com/crowdin/client/translations/TranslationsApiTest.java
@@ -103,6 +103,19 @@ public class TranslationsApiTest extends TestClient {
 
     @Test
     public void pseudoBuildProjectTranslationTest() {
+        CrowdinTranslationCreateProjectPseudoBuildForm request = new CrowdinTranslationCreateProjectPseudoBuildForm();
+        request.setBranchId(1L);
+        request.setPseudo(true);
+        request.setPrefix("pre");
+        request.setSuffix("ion");
+        request.setLengthTransformation(0);
+        request.setCharTransformation(CharTransformation.ASIAN);
+        ResponseObject<ProjectBuild> projectBuildResponseObject = this.getTranslationsApi().buildProjectTranslation(parallelProjectId, request);
+        assertEquals(projectBuildResponseObject.getData().getId(), buildId);
+    }
+
+    @Test
+    public void pseudoBuildProjectTranslationDeprecatedTest() {
         CrowdinTranslationCraeteProjectPseudoBuildForm request = new CrowdinTranslationCraeteProjectPseudoBuildForm();
         request.setBranchId(1L);
         request.setPseudo(true);


### PR DESCRIPTION
I'm hoping to deprecate `CrowdinTranslationCraeteProjectPseudoBuildForm` in favor of `CrowdinTranslationCreateProjectPseudoBuildForm`

I'm not sure what the deprecation policy is for this repository, but it does appear that this repository is willing to use `@Deprecated`