### PR TITLE
Add Docx File Import Options

### DIFF
--- a/src/main/java/com/crowdin/client/core/http/impl/json/FileImportOptionsDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/FileImportOptionsDeserializer.java
@@ -1,5 +1,6 @@
 package com.crowdin.client.core.http.impl.json;
 
+import com.crowdin.client.sourcefiles.model.DocxFileImportOptions;
 import com.crowdin.client.sourcefiles.model.ImportOptions;
 import com.crowdin.client.sourcefiles.model.OtherFileImportOptions;
 import com.crowdin.client.sourcefiles.model.SpreadsheetFileImportOptions;
@@ -31,7 +32,9 @@ public class FileImportOptionsDeserializer extends JsonDeserializer<ImportOption
         List<String> fields = StreamSupport
                 .stream(iterable.spliterator(), false)
                 .collect(Collectors.toList());
-        if (fields.contains("firstLineContainsHeader")) {
+        if (fields.contains("cleanTagsAggressively")) {
+            return this.objectMapper.readValue(treeNode.toString(), DocxFileImportOptions.class);
+        } else if (fields.contains("firstLineContainsHeader")) {
             return this.objectMapper.readValue(treeNode.toString(), SpreadsheetFileImportOptions.class);
         } else if (fields.contains("translateContent")) {
             return this.objectMapper.readValue(treeNode.toString(), XmlFileImportOptions.class);

--- a/src/main/java/com/crowdin/client/sourcefiles/model/DocxFileImportOptions.java
+++ b/src/main/java/com/crowdin/client/sourcefiles/model/DocxFileImportOptions.java
@@ -1,0 +1,19 @@
+package com.crowdin.client.sourcefiles.model;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class DocxFileImportOptions extends ImportOptions {
+
+    private Boolean cleanTagsAggressively;
+    private Boolean translateHiddenText;
+    private Boolean translateHyperlinkUrls;
+    private Boolean translateHiddenRowsAndColumns;
+    private Boolean importNotes;
+    private Boolean importHiddenSlides;
+    private Boolean contentSegmentation;
+    private Integer srxStorageId;
+
+}

--- a/src/test/java/com/crowdin/client/sourcefiles/SourceFilesApiTest.java
+++ b/src/test/java/com/crowdin/client/sourcefiles/SourceFilesApiTest.java
@@ -154,7 +154,7 @@ public class SourceFilesApiTest extends TestClient {
     @Test
     public void listFilesTest() {
         ResponseList<File> fileResponseList = (ResponseList<File>) this.getSourceFilesApi().listFiles(projectId, null, null, null, null, null, null);
-        assertEquals(fileResponseList.getData().size(), 3);
+        assertEquals(fileResponseList.getData().size(), 4);
         assertEquals(fileResponseList.getData().get(0).getData().getId(), fileId);
         assertEquals(fileResponseList.getData().get(0).getData().getName(), fileName);
         ExportOptions exportOptions = fileResponseList.getData().get(0).getData().getExportOptions();
@@ -176,6 +176,20 @@ public class SourceFilesApiTest extends TestClient {
         assertEquals(((PropertyFileExportOptions) exportOptions).getExportPattern(), "/files/fileB.properties");
         assertEquals(((PropertyFileExportOptions) exportOptions).getEscapeQuotes(), null);
         assertEquals(((PropertyFileExportOptions) exportOptions).getEscapeSpecialCharacters(), Integer.valueOf(1));
+
+        assertEquals(fileResponseList.getData().get(3).getData().getId(), Long.valueOf(47L));
+        assertEquals(fileResponseList.getData().get(3).getData().getName(), "guide.odt");
+        assertEquals(fileResponseList.getData().get(3).getData().getType(), "docx");
+        ImportOptions importOptions = fileResponseList.getData().get(3).getData().getImportOptions();
+        assertTrue(importOptions instanceof DocxFileImportOptions);
+        assertEquals(((DocxFileImportOptions) importOptions).getCleanTagsAggressively(), false);
+        assertEquals(((DocxFileImportOptions) importOptions).getTranslateHiddenText(), true);
+        assertEquals(((DocxFileImportOptions) importOptions).getTranslateHyperlinkUrls(), false);
+        assertEquals(((DocxFileImportOptions) importOptions).getTranslateHiddenRowsAndColumns(), false);
+        assertEquals(((DocxFileImportOptions) importOptions).getImportNotes(), true);
+        assertEquals(((DocxFileImportOptions) importOptions).getImportHiddenSlides(), false);
+        assertEquals(((DocxFileImportOptions) importOptions).getContentSegmentation(), true);
+        assertEquals(((DocxFileImportOptions) importOptions).getSrxStorageId(), null);
     }
 
     @Test

--- a/src/test/resources/api/sourcefiles/listFiles.json
+++ b/src/test/resources/api/sourcefiles/listFiles.json
@@ -71,6 +71,37 @@
         "createdAt": "2019-09-19T15:10:43+00:00",
         "updatedAt": "2019-09-19T15:10:46+00:00"
       }
+    },
+    {
+      "data": {
+        "id" : 47,
+        "projectId" : 2,
+        "branchId" : null,
+        "directoryId" : 5,
+        "revisionId" : 6,
+        "status" : "active",
+        "priority" : "high",
+        "importOptions" : {
+          "cleanTagsAggressively" : false,
+          "translateHiddenText" : true,
+          "translateHyperlinkUrls" : false,
+          "translateHiddenRowsAndColumns" : false,
+          "importNotes" : true,
+          "importHiddenSlides" : false,
+          "contentSegmentation" : true,
+          "customSegmentation" : false
+        },
+        "exportOptions" : {
+          "exportPattern" : "guide.odt"
+        },
+        "excludedTargetLanguages" : null,
+        "createdAt" : "2014-06-04T10:28:51+00:00",
+        "updatedAt" : "2022-02-23T09:16:35+00:00",
+        "name" : "guide.odt",
+        "title" : null,
+        "type" : "docx",
+        "path" : "/docs/guide.odt"
+      }
     }
   ],
   "pagination": {


### PR DESCRIPTION
Add support for docx file import options.

Part of #119.

---
I think this actually addresses the issue but not linking in case you notice that something is not done.
Both `Add File` and `Update or Restore File` use the same base class `ImportOptions` in the request and response.
The `Edit File` is using a `String` for the `path` parameter not an `Enum`.