### PR TITLE
Add missing params to AddScreenshotRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ repositories {
     maven { url "https://jitpack.io" }
 }
 dependencies {
-    compile "com.github.crowdin:crowdin-api-client-java:1.6.3"
+    compile "com.github.crowdin:crowdin-api-client-java:1.6.4"
 }
 ```
 
@@ -46,7 +46,7 @@ dependencies {
 <dependency>
     <groupId>com.github.crowdin</groupId>
     <artifactId>crowdin-api-client-java</artifactId>
-    <version>1.6.3</version>
+    <version>1.6.4</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ task myJavadocs(type: Javadoc) {
 }
 
 sourceCompatibility = 8
-version '1.6.3'
+version '1.6.4'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/crowdin/client/screenshots/model/AddScreenshotRequest.java
+++ b/src/main/java/com/crowdin/client/screenshots/model/AddScreenshotRequest.java
@@ -8,4 +8,5 @@ public class AddScreenshotRequest {
     private Long storageId;
     private String name;
     private Boolean autoTag;
+    private Long fileId;
 }

--- a/src/main/java/com/crowdin/client/screenshots/model/AddScreenshotRequest.java
+++ b/src/main/java/com/crowdin/client/screenshots/model/AddScreenshotRequest.java
@@ -9,4 +9,6 @@ public class AddScreenshotRequest {
     private String name;
     private Boolean autoTag;
     private Long fileId;
+    private Long branchId;
+    private Long directoryId;
 }

--- a/src/test/java/com/crowdin/client/screenshots/ScreenshotsApiTest.java
+++ b/src/test/java/com/crowdin/client/screenshots/ScreenshotsApiTest.java
@@ -35,6 +35,8 @@ public class ScreenshotsApiTest extends TestClient {
     private final Long screenshotId = 2L;
     private final Long storageId = 71L;
     private final Long fileId = 87L;
+    private final Long branchId = 88L;
+    private final Long directoryId = 89L;
     private final Long tagId = 98L;
     private final Long stringId = 12L;
     private final String name = "translate_with_siri.jpg";
@@ -72,6 +74,8 @@ public class ScreenshotsApiTest extends TestClient {
         request.setName(name);
         request.setStorageId(storageId);
         request.setFileId(fileId);
+        request.setBranchId(branchId);
+        request.setDirectoryId(directoryId);
         ResponseObject<Screenshot> screenshotResponseObject = this.getScreenshotsApi().addScreenshot(projectId, request);
         assertEquals(screenshotResponseObject.getData().getId(), screenshotId);
     }

--- a/src/test/java/com/crowdin/client/screenshots/ScreenshotsApiTest.java
+++ b/src/test/java/com/crowdin/client/screenshots/ScreenshotsApiTest.java
@@ -34,6 +34,7 @@ public class ScreenshotsApiTest extends TestClient {
     private final Long projectId = 3L;
     private final Long screenshotId = 2L;
     private final Long storageId = 71L;
+    private final Long fileId = 87L;
     private final Long tagId = 98L;
     private final Long stringId = 12L;
     private final String name = "translate_with_siri.jpg";
@@ -70,6 +71,7 @@ public class ScreenshotsApiTest extends TestClient {
         AddScreenshotRequest request = new AddScreenshotRequest();
         request.setName(name);
         request.setStorageId(storageId);
+        request.setFileId(fileId);
         ResponseObject<Screenshot> screenshotResponseObject = this.getScreenshotsApi().addScreenshot(projectId, request);
         assertEquals(screenshotResponseObject.getData().getId(), screenshotId);
     }

--- a/src/test/resources/api/screenshots/addScreenshotRequest.json
+++ b/src/test/resources/api/screenshots/addScreenshotRequest.json
@@ -1,5 +1,7 @@
 {
   "storageId": 71,
   "name": "translate_with_siri.jpg",
-  "fileId": 87
+  "fileId": 87,
+  "branchId": 88,
+  "directoryId": 89
 }

--- a/src/test/resources/api/screenshots/addScreenshotRequest.json
+++ b/src/test/resources/api/screenshots/addScreenshotRequest.json
@@ -1,4 +1,5 @@
 {
   "storageId": 71,
-  "name": "translate_with_siri.jpg"
+  "name": "translate_with_siri.jpg",
+  "fileId": 87
 }


### PR DESCRIPTION
Currently, the API supports more params compared to what's present in the java client request.
This PR adds the missing params to `AddScreenshotRequest`:
- fileId
- branchId
- directoryId