### PR TITLE
ci: automated versioning

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,19 @@
+name: Bump version
+run-name: Bump ${{ github.event.inputs.version }} version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: choice
+        description: Version
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  version:
+    permissions:
+      contents: write
+    uses: crowdin/.github/.github/workflows/bump-version.yml@main

--- a/.release-it.json
+++ b/.release-it.json
@@ -1,0 +1,33 @@
+{
+  "git": {
+    "push": true,
+    "commit": true,
+    "commitMessage": "chore: version ${version} [skip ci]",
+    "requireBranch": "master",
+    "changelog": false,
+    "tag": true
+  },
+  "github": {
+    "release": false
+  },
+  "plugins": {
+    "@j-ulrich/release-it-regex-bumper": {
+      "in": "build.gradle",
+      "out": [
+        {
+          "file": "README.md",
+          "search": {
+            "pattern": "\\d+\\.\\d+\\.\\d+",
+            "flags": "g"
+          },
+          "replace": "{{versionWithoutPrerelease}}"
+        },
+        {
+          "file": "build.gradle",
+          "search": "^version '\\d+\\.\\d+\\.\\d+'",
+          "replace": "version '{{versionWithoutPrerelease}}'"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Using the [release-it](https://www.npmjs.com/package/release-it) CLI.

Based on the reusable workflow [crowdin/.github/.github/workflows/bump-version.yml](https://github.com/crowdin/.github/blob/main/.github/workflows/bump-version.yml).