### PR TITLE
test: Add more Unit tests for the notifications package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 *.class
 .gradle
 
+#MacOS
+.DS_Store
+
 /target
 /build
 /out

--- a/src/main/java/com/crowdin/client/notifications/NotificationsApi.java
+++ b/src/main/java/com/crowdin/client/notifications/NotificationsApi.java
@@ -11,6 +11,7 @@ import com.crowdin.client.notifications.model.SendNotificationToOrganizationMemb
 import com.crowdin.client.notifications.model.SendNotificationToProjectMemberRequest;
 
 public class NotificationsApi extends  CrowdinApi {
+
     public NotificationsApi(Credentials credentials) {
         super(credentials);
     }

--- a/src/test/java/com/crowdin/client/notifications/NotificationsApiTest.java
+++ b/src/test/java/com/crowdin/client/notifications/NotificationsApiTest.java
@@ -3,6 +3,9 @@ package com.crowdin.client.notifications;
 import com.crowdin.client.framework.RequestMock;
 import com.crowdin.client.framework.TestClient;
 import com.crowdin.client.notifications.model.SendNotificationToAuthenticatedUserRequest;
+import com.crowdin.client.notifications.model.SendNotificationToOrganizationMembersByRoleRequest;
+import com.crowdin.client.notifications.model.SendNotificationToOrganizationMembersByUserIdsRequest;
+import com.crowdin.client.notifications.model.SendNotificationToOrganizationMembersRequest;
 import com.crowdin.client.notifications.model.SendNotificationToProjectMemberRequest;
 import com.crowdin.client.notifications.model.SendNotificationToProjectMemberByRoleRequest;
 import org.apache.http.client.methods.HttpPost;
@@ -13,14 +16,32 @@ import java.util.List;
 
 public class NotificationsApiTest extends TestClient {
     private final Long projectId = 8L;
-    private final List<Long> userIds = Arrays.asList(1l,2L);
+    private final List<Long> userIds = Arrays.asList(1L,2L);
 
     @Override
     public List<RequestMock> getMocks() {
         return Arrays.asList(
-                RequestMock.buildWithRequestFileOnly(this.url + "/notify", HttpPost.METHOD_NAME,"api/notifications/notificationRequestToAuthenticatedUsers.json"),
-                RequestMock.buildWithRequestFileOnly(String.format("%s/projects/%d/notify",this.url,projectId), HttpPost.METHOD_NAME, "api/notifications/notificationRequestToProjectMembersByRole.json")
-                );
+            RequestMock.buildWithRequestFileOnly(
+                this.url + "/notify",
+                HttpPost.METHOD_NAME,
+                "api/notifications/notificationRequestToAuthenticatedUsers.json"
+            ),
+            RequestMock.buildWithRequestFileOnly(
+                String.format("%s/projects/%d/notify",this.url,projectId),
+                HttpPost.METHOD_NAME,
+                "api/notifications/notificationRequestToProjectMembersByRole.json"
+            ),
+            RequestMock.buildWithRequestFileOnly(
+                String.format("%s/notify", this.url),
+                HttpPost.METHOD_NAME,
+                "api/notifications/notificationRequestToOrganizationMembersByRole.json"
+            ),
+            RequestMock.buildWithRequestFileOnly(
+                String.format("%s/notify", this.url),
+                HttpPost.METHOD_NAME,
+                "api/notifications/notificationRequestToOrganizationMembersByUserIds.json"
+            )
+        );
     }
 
     @Test
@@ -33,11 +54,30 @@ public class NotificationsApiTest extends TestClient {
 
 
     @Test
-    public void sendNotificationToProjectMembersByRole(){
+    public void sendNotificationToProjectMembersByRoleTest(){
         SendNotificationToProjectMemberRequest request = new SendNotificationToProjectMemberByRoleRequest(){{
                 setRole("owner");
                 setMessage("Hiii...");
             }};
-        this.getNotificationsApi().sendNotificationToProjectMembers(projectId,request);
+        this.getNotificationsApi().sendNotificationToProjectMembers(projectId, request);
     }
+
+    @Test
+    public void sendNotificationToOrganizationMembersByUserIdsTest() {
+        SendNotificationToOrganizationMembersRequest request = new SendNotificationToOrganizationMembersByUserIdsRequest() {{
+            setUserIds(userIds);
+            setMessage("Hiii...");
+        }};
+        this.getNotificationsApi().sendNotificationToOrganizationMembers(request);
+    }
+
+    @Test
+    public void sendNotificationToOrganizationMembersByRoleTest() {
+        SendNotificationToOrganizationMembersRequest request = new SendNotificationToOrganizationMembersByRoleRequest() {{
+            setRole("owner");
+            setMessage("Hiii...");
+        }};
+        this.getNotificationsApi().sendNotificationToOrganizationMembers(request);
+    }
+
 }

--- a/src/test/resources/api/notifications/notificationRequestToOrganizationMembersByRole.json
+++ b/src/test/resources/api/notifications/notificationRequestToOrganizationMembersByRole.json
@@ -1,4 +1,4 @@
 {
   "role": "owner",
-  "message": "New notification message to Admin"
+  "message": "Hiii..."
 }

--- a/src/test/resources/api/notifications/notificationRequestToOrganizationMembersByUserIds.json
+++ b/src/test/resources/api/notifications/notificationRequestToOrganizationMembersByUserIds.json
@@ -1,6 +1,6 @@
 {
   "userIds": [
-    2
+    1, 2
   ],
-  "message": "New notification message"
+  "message": "Hiii..."
 }


### PR DESCRIPTION
Closes #196.

@andrii-bodnar I've added a couple of tests, but I've encountered an issue.

The tests could not be initialized due to the fact that

1. sendNotificationToOrganizationMembersByRoleTest()
2. sendNotificationToOrganizationMembersByUserIdsTest()
3. sendNotificationToAuthenticatedUserTest()

Hit the same URL, so they cannot be collected to a HashMap.

I've introduced a workaround: moved from `Map<String, RequestMock>` to `Map<String, List<RequestMock>>` inside TestHttpClient. If you have any suggestions on how to make it better, I will make the improvements 