### PR TITLE
fix: removed the `markAddedTranslationsAsDone` parameter

### DIFF
--- a/src/main/java/com/crowdin/client/translations/model/ApplyPreTranslationRequest.java
+++ b/src/main/java/com/crowdin/client/translations/model/ApplyPreTranslationRequest.java
@@ -15,7 +15,6 @@ public class ApplyPreTranslationRequest {
     private Boolean duplicateTranslations;
     private Boolean translateUntranslatedOnly;
     private Boolean translateWithPerfectMatchOnly;
-    private Boolean markAddedTranslationsAsDone;
     private List<Long> labelIds;
     private List<Long> excludeLabelIds;
 }

--- a/src/main/java/com/crowdin/client/translations/model/ApplyPreTranslationStringsBasedRequest.java
+++ b/src/main/java/com/crowdin/client/translations/model/ApplyPreTranslationStringsBasedRequest.java
@@ -16,7 +16,6 @@ public class ApplyPreTranslationStringsBasedRequest {
     private Boolean skipApprovedTranslations;
     private Boolean translateUntranslatedOnly;
     private Boolean translateWithPerfectMatchOnly;
-    private Boolean markAddedTranslationsAsDone;
     private List<FallbackLanguage> fallbackLanguages;
     private List<Long> labelIds;
     private List<Long> excludeLabelIds;

--- a/src/main/java/com/crowdin/client/translations/model/PreTranslationStatus.java
+++ b/src/main/java/com/crowdin/client/translations/model/PreTranslationStatus.java
@@ -28,7 +28,6 @@ public class PreTranslationStatus {
         private boolean skipApprovedTranslations;
         private boolean translateUntranslatedOnly;
         private boolean translateWithPerfectMatchOnly;
-        private boolean markAddedTranslationsAsDone;
         private List<Long> labelIds;
         private List<Long> excludeLabelIds;
     }

--- a/src/main/java/com/crowdin/client/translations/model/UploadTranslationsRequest.java
+++ b/src/main/java/com/crowdin/client/translations/model/UploadTranslationsRequest.java
@@ -10,5 +10,4 @@ public class UploadTranslationsRequest {
     private Boolean importEqSuggestions;
     private Boolean autoApproveImported;
     private Boolean translateHidden;
-    private Boolean markAddedTranslationsAsDone;
 }


### PR DESCRIPTION
This change resolves issue #229 by removing the deprecated `markAddedTranslationsAsDone` parameter from the API, which should be removed from the codebase.