### PR TITLE
feat: add new Report Archives API endpoints

### DIFF
--- a/src/main/java/com/crowdin/client/reports/ReportsApi.java
+++ b/src/main/java/com/crowdin/client/reports/ReportsApi.java
@@ -216,4 +216,101 @@ public class ReportsApi extends CrowdinApi {
     public void deleteReportSettingsTemplate(Long projectId, Long reportSettingsTemplateId) throws HttpException, HttpBadRequestException {
         this.httpClient.delete(this.url + "/projects/" + projectId + "/settings-templates/" + reportSettingsTemplateId, new HttpRequestConfig(), Void.class);
     }
+
+    // -- REPORT ARCHIVES -- //
+
+    /**
+     * @param userId    user identifier
+     * @param scopeType Filter only project report archives (scopeType=project)
+     * @param scopeId   Filter archives by spicific scope id (default 25)
+     * @param limit     maximum number of items to retrieve (default 25)
+     * @param offset    starting offset in the collection (default 0)
+     * @return list of report settings template
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.reports.archives.getMany" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.reports.settings-templates.getMany" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseList<ReportArchive> getListReportArchives(Long userId, String scopeType, Long scopeId, Integer limit, Integer offset) throws HttpException, HttpBadRequestException {
+        Map<String, Optional<Object>> queryParams = HttpRequestConfig.buildUrlParams(
+                "scopeType", Optional.ofNullable(scopeType),
+                "scopeId", Optional.ofNullable(scopeId),
+                "limit", Optional.ofNullable(limit),
+                "offset", Optional.ofNullable(offset)
+        );
+        ReportArchiveList responseObject = this.httpClient.get(this.url + "/users/" + userId + "/reports/archives/", new HttpRequestConfig(queryParams), ReportArchiveList.class);
+        return ReportArchiveList.to(responseObject);
+    }
+
+    /**
+     * @param userId    user identifier
+     * @param archiveId archive identifier
+     * @return download link
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.users.reports.archives.get" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.reports.archives.get" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseObject<ReportArchive> getReportArchive(Long userId, Long archiveId) throws HttpException, HttpBadRequestException {
+        ReportArchiveResponseObject reportArchiveResponseObject = this.httpClient.get(this.url + "/users/" + userId + "/reports/archives/" + archiveId, new HttpRequestConfig(), ReportArchiveResponseObject.class);
+        return ResponseObject.of(reportArchiveResponseObject.getData());
+    }
+
+    /**
+     * @param userId    user identifier
+     * @param archiveId archive identifier
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.users.reports.archives.delete" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.reports.archives.delete" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public void deleteReportArchive(Long userId, Long archiveId) throws HttpException, HttpBadRequestException {
+        this.httpClient.delete(this.url + "/users/" + userId + "/reports/archives/" + archiveId, new HttpRequestConfig(), Void.class);
+    }
+
+    /**
+     * @param userId    user identifier
+     * @param archiveId archive identifier
+     * @param request   request object
+     * @return report settings template
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.reports.archives.exports.post" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.reports.archives.exports.post" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseObject<GroupReportStatus> exportReportArchive(Long userId, Long archiveId, ExportReportRequest request) throws HttpException, HttpBadRequestException {
+        GroupReportStatusResponseObject responseObject = this.httpClient.post(this.url + "/users/" + userId + "/reports/archives/" + archiveId + "/exports", request, new HttpRequestConfig(), GroupReportStatusResponseObject.class);
+        return ResponseObject.of(responseObject.getData());
+    }
+
+    /**
+     * @param archiveId archive identifier
+     * @param exportId  export identifier
+     * @return export report status
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.reports.archives.exports.get" target="_blank"><b> API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.reports.archives.exports.get" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseObject<GroupReportStatus> chechReportArchiveExportStatus(Long archiveId, String exportId) throws HttpException, HttpBadRequestException {
+        String url = this.url + "/reports/archives" + archiveId + "/exports/" + exportId;
+        GroupReportStatusResponseObject responseObject = this.httpClient.get(url, new HttpRequestConfig(), GroupReportStatusResponseObject.class);
+        return ResponseObject.of(responseObject.getData());
+    }
+
+    /**
+     * @param userId    user identifier
+     * @param archiveId archive identifier
+     * @param exportId  export identifier
+     * @return report archive download link
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.users.reports.archives.exports.download.get" target="_blank"><b> API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.reports.archives.exports.download.get" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseObject<DownloadLink> downloadReportArchive(Long userId, Long archiveId, String exportId) throws HttpException, HttpBadRequestException {
+        String url = this.url + "/users/" + userId + "/reports/archives" + archiveId + "/exports/" + exportId + "/download";
+        DownloadLinkResponseObject responseObject = this.httpClient.get(url, new HttpRequestConfig(), DownloadLinkResponseObject.class);
+        return ResponseObject.of(responseObject.getData());
+    }
 }

--- a/src/main/java/com/crowdin/client/reports/ReportsApi.java
+++ b/src/main/java/com/crowdin/client/reports/ReportsApi.java
@@ -228,18 +228,18 @@ public class ReportsApi extends CrowdinApi {
      * @return list of report settings template
      * @see <ul>
      * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.reports.archives.getMany" target="_blank"><b>API Documentation</b></a></li>
-     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.reports.settings-templates.getMany" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.reports.archives.getMany" target="_blank"><b>Enterprise API Documentation</b></a></li>
      * </ul>
      */
     public ResponseList<ReportArchive> listReportArchives(Long userId, String scopeType, Long scopeId, Integer limit, Integer offset) throws HttpException, HttpBadRequestException {
-        String url = getUserPrefixedUrl(userId);
+        String url = getReportArchivesPath(userId, "reports/archives/");
         Map<String, Optional<Object>> queryParams = HttpRequestConfig.buildUrlParams(
                 "scopeType", Optional.ofNullable(scopeType),
                 "scopeId", Optional.ofNullable(scopeId),
                 "limit", Optional.ofNullable(limit),
                 "offset", Optional.ofNullable(offset)
         );
-        ReportArchiveList responseObject = this.httpClient.get(url + "/reports/archives/", new HttpRequestConfig(queryParams), ReportArchiveList.class);
+        ReportArchiveList responseObject = this.httpClient.get(url, new HttpRequestConfig(queryParams), ReportArchiveList.class);
         return ReportArchiveList.to(responseObject);
     }
 
@@ -253,8 +253,8 @@ public class ReportsApi extends CrowdinApi {
      * </ul>
      */
     public ResponseObject<ReportArchive> getReportArchive(Long userId, Long archiveId) throws HttpException, HttpBadRequestException {
-        String url = getUserPrefixedUrl(userId);
-        ReportArchiveResponseObject reportArchiveResponseObject = this.httpClient.get(url + "/reports/archives/" + archiveId, new HttpRequestConfig(), ReportArchiveResponseObject.class);
+        String url = getReportArchivesPath(userId, "reports/archives/" + archiveId);
+        ReportArchiveResponseObject reportArchiveResponseObject = this.httpClient.get(url, new HttpRequestConfig(), ReportArchiveResponseObject.class);
         return ResponseObject.of(reportArchiveResponseObject.getData());
     }
 
@@ -267,8 +267,8 @@ public class ReportsApi extends CrowdinApi {
      * </ul>
      */
     public void deleteReportArchive(Long userId, Long archiveId) throws HttpException, HttpBadRequestException {
-        String url = getUserPrefixedUrl(userId);
-        this.httpClient.delete(url + "/reports/archives/" + archiveId, new HttpRequestConfig(), Void.class);
+        String url = getReportArchivesPath(userId, "reports/archives/" + archiveId);
+        this.httpClient.delete(url, new HttpRequestConfig(), Void.class);
     }
 
     /**
@@ -282,8 +282,8 @@ public class ReportsApi extends CrowdinApi {
      * </ul>
      */
     public ResponseObject<GroupReportStatus> exportReportArchive(Long userId, Long archiveId, ExportReportRequest request) throws HttpException, HttpBadRequestException {
-        String url = getUserPrefixedUrl(userId);
-        GroupReportStatusResponseObject responseObject = this.httpClient.post(url + "/reports/archives/" + archiveId + "/exports", request, new HttpRequestConfig(), GroupReportStatusResponseObject.class);
+        String url = getReportArchivesPath(userId, "reports/archives/" + archiveId + "/exports");
+        GroupReportStatusResponseObject responseObject = this.httpClient.post(url, request, new HttpRequestConfig(), GroupReportStatusResponseObject.class);
         return ResponseObject.of(responseObject.getData());
     }
 
@@ -296,8 +296,9 @@ public class ReportsApi extends CrowdinApi {
      * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.reports.archives.exports.get" target="_blank"><b>Enterprise API Documentation</b></a></li>
      * </ul>
      */
-    public ResponseObject<GroupReportStatus> checkReportArchiveExportStatus(Long archiveId, String exportId) throws HttpException, HttpBadRequestException {
-        GroupReportStatusResponseObject responseObject = this.httpClient.get(this.url + "/reports/archives" + archiveId + "/exports/" + exportId, new HttpRequestConfig(), GroupReportStatusResponseObject.class);
+    public ResponseObject<GroupReportStatus> checkReportArchiveExportStatus(Long userId, Long archiveId, String exportId) throws HttpException, HttpBadRequestException {
+        String url = getReportArchivesPath(userId, "reports/archives/" + archiveId + "/exports/" + exportId);
+        GroupReportStatusResponseObject responseObject = this.httpClient.get(url, new HttpRequestConfig(), GroupReportStatusResponseObject.class);
         return ResponseObject.of(responseObject.getData());
     }
 
@@ -312,17 +313,19 @@ public class ReportsApi extends CrowdinApi {
      * </ul>
      */
     public ResponseObject<DownloadLink> downloadReportArchive(Long userId, Long archiveId, String exportId) throws HttpException, HttpBadRequestException {
-        String url = getUserPrefixedUrl(userId);
-        DownloadLinkResponseObject responseObject = this.httpClient.get(url + "/reports/archives" + archiveId + "/exports/" + exportId + "/download", new HttpRequestConfig(), DownloadLinkResponseObject.class);
+        String url = getReportArchivesPath(userId, "reports/archives" + archiveId + "/exports/" + exportId + "/download");
+        DownloadLinkResponseObject responseObject = this.httpClient.get(url, new HttpRequestConfig(), DownloadLinkResponseObject.class);
         return ResponseObject.of(responseObject.getData());
     }
 
     /**
      * Build an url with or without userId prefix
-     * @param userId user identifier
+     *
+     * @param userId user identifier (for crowdin.com only)
+     * @param path   sub-path of the url
      * @return url with userId prefix if exist
      */
-    private String getUserPrefixedUrl(Long userId) {
-        return userId != null ? this.url + "/users/" + userId : this.url;
+    private String getReportArchivesPath(Long userId, String path) {
+        return userId != null ? String.format("%s/users/%d/%s", this.url, userId, path) : String.format("%s/%s", this.url, path);
     }
 }

--- a/src/main/java/com/crowdin/client/reports/ReportsApi.java
+++ b/src/main/java/com/crowdin/client/reports/ReportsApi.java
@@ -35,7 +35,7 @@ public class ReportsApi extends CrowdinApi {
     }
 
     /**
-     * @param groupId group identifier
+     * @param groupId  group identifier
      * @param reportId report identifier
      * @return group report status
      * @see <ul>
@@ -49,7 +49,7 @@ public class ReportsApi extends CrowdinApi {
     }
 
     /**
-     * @param groupId group identifier
+     * @param groupId  group identifier
      * @param reportId report identifier
      * @return report download link
      * @see <ul>
@@ -103,7 +103,7 @@ public class ReportsApi extends CrowdinApi {
 
     /**
      * @param projectId project identifier
-     * @param request request object
+     * @param request   request object
      * @return report status
      * @see <ul>
      * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.projects.reports.post" target="_blank"><b>API Documentation</b></a></li>
@@ -117,7 +117,7 @@ public class ReportsApi extends CrowdinApi {
 
     /**
      * @param projectId project identifier
-     * @param reportId report identifier
+     * @param reportId  report identifier
      * @return report status
      * @see <ul>
      * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.projects.reports.get" target="_blank"><b>API Documentation</b></a></li>
@@ -131,7 +131,7 @@ public class ReportsApi extends CrowdinApi {
 
     /**
      * @param projectId project identifier
-     * @param reportId report identifier
+     * @param reportId  report identifier
      * @return download link
      * @see <ul>
      * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.projects.reports.download.download" target="_blank"><b>API Documentation</b></a></li>
@@ -145,8 +145,8 @@ public class ReportsApi extends CrowdinApi {
 
     /**
      * @param projectId project identifier
-     * @param limit maximum number of items to retrieve (default 25)
-     * @param offset starting offset in the collection (default 0)
+     * @param limit     maximum number of items to retrieve (default 25)
+     * @param offset    starting offset in the collection (default 0)
      * @return list of report settings template
      * @see <ul>
      * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.projects.reports.settings-templates.getMany" target="_blank"><b>API Documentation</b></a></li>
@@ -164,7 +164,7 @@ public class ReportsApi extends CrowdinApi {
 
     /**
      * @param projectId project identifier
-     * @param request request object
+     * @param request   request object
      * @return report settings template
      * @see <ul>
      * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.projects.reports.settings-templates.post" target="_blank"><b>API Documentation</b></a></li>
@@ -177,7 +177,7 @@ public class ReportsApi extends CrowdinApi {
     }
 
     /**
-     * @param projectId project identifier
+     * @param projectId                project identifier
      * @param reportSettingsTemplateId report settings template identifier
      * @return report settings template
      * @see <ul>
@@ -191,9 +191,9 @@ public class ReportsApi extends CrowdinApi {
     }
 
     /**
-     * @param projectId project identifier
+     * @param projectId                project identifier
      * @param reportSettingsTemplateId report settings template identifier
-     * @param request request object
+     * @param request                  request object
      * @return report settings template
      * @see <ul>
      * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.projects.reports.settings-templates.patch" target="_blank"><b>API Documentation</b></a></li>
@@ -206,7 +206,7 @@ public class ReportsApi extends CrowdinApi {
     }
 
     /**
-     * @param projectId project identifier
+     * @param projectId                project identifier
      * @param reportSettingsTemplateId report settings template identifier
      * @see <ul>
      * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.projects.settings-templates.delete" target="_blank"><b>API Documentation</b></a></li>
@@ -231,14 +231,15 @@ public class ReportsApi extends CrowdinApi {
      * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.reports.settings-templates.getMany" target="_blank"><b>Enterprise API Documentation</b></a></li>
      * </ul>
      */
-    public ResponseList<ReportArchive> getListReportArchives(Long userId, String scopeType, Long scopeId, Integer limit, Integer offset) throws HttpException, HttpBadRequestException {
+    public ResponseList<ReportArchive> listReportArchives(Long userId, String scopeType, Long scopeId, Integer limit, Integer offset) throws HttpException, HttpBadRequestException {
+        String url = getUserPrefixedUrl(userId);
         Map<String, Optional<Object>> queryParams = HttpRequestConfig.buildUrlParams(
                 "scopeType", Optional.ofNullable(scopeType),
                 "scopeId", Optional.ofNullable(scopeId),
                 "limit", Optional.ofNullable(limit),
                 "offset", Optional.ofNullable(offset)
         );
-        ReportArchiveList responseObject = this.httpClient.get(this.url + "/users/" + userId + "/reports/archives/", new HttpRequestConfig(queryParams), ReportArchiveList.class);
+        ReportArchiveList responseObject = this.httpClient.get(url + "/reports/archives/", new HttpRequestConfig(queryParams), ReportArchiveList.class);
         return ReportArchiveList.to(responseObject);
     }
 
@@ -252,7 +253,8 @@ public class ReportsApi extends CrowdinApi {
      * </ul>
      */
     public ResponseObject<ReportArchive> getReportArchive(Long userId, Long archiveId) throws HttpException, HttpBadRequestException {
-        ReportArchiveResponseObject reportArchiveResponseObject = this.httpClient.get(this.url + "/users/" + userId + "/reports/archives/" + archiveId, new HttpRequestConfig(), ReportArchiveResponseObject.class);
+        String url = getUserPrefixedUrl(userId);
+        ReportArchiveResponseObject reportArchiveResponseObject = this.httpClient.get(url + "/reports/archives/" + archiveId, new HttpRequestConfig(), ReportArchiveResponseObject.class);
         return ResponseObject.of(reportArchiveResponseObject.getData());
     }
 
@@ -265,7 +267,8 @@ public class ReportsApi extends CrowdinApi {
      * </ul>
      */
     public void deleteReportArchive(Long userId, Long archiveId) throws HttpException, HttpBadRequestException {
-        this.httpClient.delete(this.url + "/users/" + userId + "/reports/archives/" + archiveId, new HttpRequestConfig(), Void.class);
+        String url = getUserPrefixedUrl(userId);
+        this.httpClient.delete(url + "/reports/archives/" + archiveId, new HttpRequestConfig(), Void.class);
     }
 
     /**
@@ -279,7 +282,8 @@ public class ReportsApi extends CrowdinApi {
      * </ul>
      */
     public ResponseObject<GroupReportStatus> exportReportArchive(Long userId, Long archiveId, ExportReportRequest request) throws HttpException, HttpBadRequestException {
-        GroupReportStatusResponseObject responseObject = this.httpClient.post(this.url + "/users/" + userId + "/reports/archives/" + archiveId + "/exports", request, new HttpRequestConfig(), GroupReportStatusResponseObject.class);
+        String url = getUserPrefixedUrl(userId);
+        GroupReportStatusResponseObject responseObject = this.httpClient.post(url + "/reports/archives/" + archiveId + "/exports", request, new HttpRequestConfig(), GroupReportStatusResponseObject.class);
         return ResponseObject.of(responseObject.getData());
     }
 
@@ -292,9 +296,8 @@ public class ReportsApi extends CrowdinApi {
      * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.reports.archives.exports.get" target="_blank"><b>Enterprise API Documentation</b></a></li>
      * </ul>
      */
-    public ResponseObject<GroupReportStatus> chechReportArchiveExportStatus(Long archiveId, String exportId) throws HttpException, HttpBadRequestException {
-        String url = this.url + "/reports/archives" + archiveId + "/exports/" + exportId;
-        GroupReportStatusResponseObject responseObject = this.httpClient.get(url, new HttpRequestConfig(), GroupReportStatusResponseObject.class);
+    public ResponseObject<GroupReportStatus> checkReportArchiveExportStatus(Long archiveId, String exportId) throws HttpException, HttpBadRequestException {
+        GroupReportStatusResponseObject responseObject = this.httpClient.get(this.url + "/reports/archives" + archiveId + "/exports/" + exportId, new HttpRequestConfig(), GroupReportStatusResponseObject.class);
         return ResponseObject.of(responseObject.getData());
     }
 
@@ -309,8 +312,17 @@ public class ReportsApi extends CrowdinApi {
      * </ul>
      */
     public ResponseObject<DownloadLink> downloadReportArchive(Long userId, Long archiveId, String exportId) throws HttpException, HttpBadRequestException {
-        String url = this.url + "/users/" + userId + "/reports/archives" + archiveId + "/exports/" + exportId + "/download";
-        DownloadLinkResponseObject responseObject = this.httpClient.get(url, new HttpRequestConfig(), DownloadLinkResponseObject.class);
+        String url = getUserPrefixedUrl(userId);
+        DownloadLinkResponseObject responseObject = this.httpClient.get(url + "/reports/archives" + archiveId + "/exports/" + exportId + "/download", new HttpRequestConfig(), DownloadLinkResponseObject.class);
         return ResponseObject.of(responseObject.getData());
+    }
+
+    /**
+     * Build an url with or without userId prefix
+     * @param userId user identifier
+     * @return url with userId prefix if exist
+     */
+    private String getUserPrefixedUrl(Long userId) {
+        return userId != null ? this.url + "/users/" + userId : this.url;
     }
 }

--- a/src/main/java/com/crowdin/client/reports/model/ExportReportRequest.java
+++ b/src/main/java/com/crowdin/client/reports/model/ExportReportRequest.java
@@ -1,0 +1,8 @@
+package com.crowdin.client.reports.model;
+
+import lombok.Data;
+
+@Data
+public class ExportReportRequest {
+    private ReportsFormat format;
+}

--- a/src/main/java/com/crowdin/client/reports/model/ReportArchive.java
+++ b/src/main/java/com/crowdin/client/reports/model/ReportArchive.java
@@ -1,0 +1,17 @@
+package com.crowdin.client.reports.model;
+
+import lombok.Data;
+
+import java.util.Date;
+
+@Data
+public class ReportArchive {
+    private Long id;
+    private String scopeType;
+    private Long scopeId;
+    private Long userId;
+    private String name;
+    private String webUrl;
+    private Object scheme;
+    private Date createdAt;
+}

--- a/src/main/java/com/crowdin/client/reports/model/ReportArchiveList.java
+++ b/src/main/java/com/crowdin/client/reports/model/ReportArchiveList.java
@@ -1,0 +1,25 @@
+package com.crowdin.client.reports.model;
+
+import com.crowdin.client.core.model.Pagination;
+import com.crowdin.client.core.model.ResponseList;
+import com.crowdin.client.core.model.ResponseObject;
+import lombok.Data;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+public class ReportArchiveList {
+    private List<ReportArchiveResponseObject> data;
+    private Pagination pagination;
+
+    public static ResponseList<ReportArchive> to(ReportArchiveList reportArchiveList) {
+        return ResponseList.of(
+                reportArchiveList.getData().stream()
+                        .map(ReportArchiveResponseObject::getData)
+                        .map(ResponseObject::of)
+                        .collect(Collectors.toList()),
+                reportArchiveList.getPagination()
+        );
+    }
+}

--- a/src/main/java/com/crowdin/client/reports/model/ReportArchiveResponseObject.java
+++ b/src/main/java/com/crowdin/client/reports/model/ReportArchiveResponseObject.java
@@ -1,0 +1,8 @@
+package com.crowdin.client.reports.model;
+
+import lombok.Data;
+
+@Data
+public class ReportArchiveResponseObject {
+    private ReportArchive data;
+}

--- a/src/test/java/com/crowdin/client/reports/ReportsApiTest.java
+++ b/src/test/java/com/crowdin/client/reports/ReportsApiTest.java
@@ -59,7 +59,7 @@ public class ReportsApiTest extends TestClient {
                 RequestMock.build(this.url + "/users/" + userId + "/reports/archives/" + archiveId, HttpGet.METHOD_NAME, "api/reports/reportArchive.json"),
                 RequestMock.build(this.url + "/users/" + userId + "/reports/archives/" + archiveId, HttpDelete.METHOD_NAME),
                 RequestMock.build(this.url + "/users/" + userId + "/reports/archives/" + archiveId + "/exports", HttpPost.METHOD_NAME, "api/reports/exportReportArchiveReques.json", "api/reports/reportGenerationStatus.json"),
-                RequestMock.build(this.url + "/reports/archives" + archiveId + "/exports/" + exportId, HttpGet.METHOD_NAME, "api/reports/reportGenerationStatus.json"),
+                RequestMock.build(this.url + "/users/" + userId + "/reports/archives/" + archiveId + "/exports/" + exportId, HttpGet.METHOD_NAME, "api/reports/reportGenerationStatus.json"),
                 RequestMock.build(this.url + "/users/" + userId + "/reports/archives" + archiveId + "/exports/" + exportId + "/download", HttpGet.METHOD_NAME, "api/reports/downloadLink.json"));
     }
 
@@ -215,7 +215,7 @@ public class ReportsApiTest extends TestClient {
 
     @Test
     public void checkReportArchiveExportStatusTest() {
-        ResponseObject<GroupReportStatus> reportStatusResponseObject = this.getReportsApi().checkReportArchiveExportStatus(archiveId, exportId);
+        ResponseObject<GroupReportStatus> reportStatusResponseObject = this.getReportsApi().checkReportArchiveExportStatus(userId, archiveId, exportId);
         assertEquals(reportStatusResponseObject.getData().getIdentifier(), id);
     }
 

--- a/src/test/java/com/crowdin/client/reports/ReportsApiTest.java
+++ b/src/test/java/com/crowdin/client/reports/ReportsApiTest.java
@@ -179,7 +179,7 @@ public class ReportsApiTest extends TestClient {
 
     @Test
     public void getListReportArchivesTest() {
-        ResponseList<ReportArchive> responseObject = this.getReportsApi().getListReportArchives(userId, null, null, null, null);
+        ResponseList<ReportArchive> responseObject = this.getReportsApi().listReportArchives(userId, null, null, null, null);
         assertEquals(responseObject.getData().size(), 1);
         assertEquals(responseObject.getData().get(0).getData().getId(), archiveId);
         assertEquals(responseObject.getData().get(0).getData().getScopeType(), scopeType);
@@ -215,7 +215,7 @@ public class ReportsApiTest extends TestClient {
 
     @Test
     public void checkReportArchiveExportStatusTest() {
-        ResponseObject<GroupReportStatus> reportStatusResponseObject = this.getReportsApi().chechReportArchiveExportStatus(archiveId, exportId);
+        ResponseObject<GroupReportStatus> reportStatusResponseObject = this.getReportsApi().checkReportArchiveExportStatus(archiveId, exportId);
         assertEquals(reportStatusResponseObject.getData().getIdentifier(), id);
     }
 

--- a/src/test/resources/api/reports/exportReportArchiveReques.json
+++ b/src/test/resources/api/reports/exportReportArchiveReques.json
@@ -1,0 +1,3 @@
+{
+  "format": "xlsx"
+}

--- a/src/test/resources/api/reports/listReportArchives.json
+++ b/src/test/resources/api/reports/listReportArchives.json
@@ -1,0 +1,20 @@
+{
+  "data": [
+    {
+      "data": {
+        "id": 1,
+        "scopeType": "project",
+        "scopeId": 1,
+        "userId": 1,
+        "name": "my archive report",
+        "webUrl": "https://crowdin.com/project/project-identifier/reports/archive/1",
+        "scheme": {},
+        "createdAt": "2019-09-23T11:26:54+00:00"
+      }
+    }
+  ],
+  "pagination": {
+    "offset": 0,
+    "limit": 25
+  }
+}

--- a/src/test/resources/api/reports/reportArchive.json
+++ b/src/test/resources/api/reports/reportArchive.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "id": 1,
+    "scopeType": "project",
+    "scopeId": 1,
+    "userId": 1,
+    "name": "my report archive",
+    "webUrl": "https://crowdin.com/project/project-identifier/reports/archive/1",
+    "scheme": {},
+    "createdAt": "2019-09-23T11:26:54+00:00"
+  }
+}


### PR DESCRIPTION
Implemented new endpoints in the Crowdin API for enhanced functionality that allows you to see the history of your reports.

Issue:[#241 ](https://github.com/crowdin/crowdin-api-client-java/issues/241)