### PR TITLE
feat: Screenshots APIs: add the stringIds parameter support

### DIFF
--- a/src/main/java/com/crowdin/client/screenshots/ScreenshotsApi.java
+++ b/src/main/java/com/crowdin/client/screenshots/ScreenshotsApi.java
@@ -44,9 +44,32 @@ public class ScreenshotsApi extends CrowdinApi {
      * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.screenshots.getMany" target="_blank"><b>Enterprise API Documentation</b></a></li>
      * </ul>
      */
-    public ResponseList<Screenshot> listScreenshots(Long projectId,@Deprecated Long stringId ,List<String> stringIds,List<String> labelIds,List<String> excludeLabelIds, Integer limit, Integer offset) throws HttpException, HttpBadRequestException {
+    @Deprecated
+    public ResponseList<Screenshot> listScreenshots(Long projectId, Long stringId, Integer limit, Integer offset) throws HttpException, HttpBadRequestException {
         Map<String, Optional<Object>> queryParams = HttpRequestConfig.buildUrlParams(
                 "stringId", Optional.ofNullable(stringId),
+                "limit", Optional.ofNullable(limit),
+                "offset", Optional.ofNullable(offset)
+        );
+        ScreenshotResponseList screenshotResponseList = this.httpClient.get(this.url + "/projects/" + projectId + "/screenshots", new HttpRequestConfig(queryParams), ScreenshotResponseList.class);
+        return ScreenshotResponseList.to(screenshotResponseList);
+    }
+
+    /**
+     * @param projectId project identifier
+     * @param stringIds string identifiers
+     * @param labelIds label identifiers
+     * @param excludeLabelIds exclude label identifiers
+     * @param limit maximum number of items to retrieve (default 25)
+     * @param offset starting offset in the collection (default 0)
+     * @return list of screenshots
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.projects.screenshots.getMany" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.screenshots.getMany" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseList<Screenshot> listScreenshots(Long projectId, List<String> stringIds, List<String> labelIds, List<String> excludeLabelIds, Integer limit, Integer offset) throws HttpException, HttpBadRequestException {
+        Map<String, Optional<Object>> queryParams = HttpRequestConfig.buildUrlParams(
                 "stringIds", Optional.ofNullable(stringIds),
                 "labelIds", Optional.ofNullable(labelIds),
                 "excludeLabelIds", Optional.ofNullable(excludeLabelIds),

--- a/src/main/java/com/crowdin/client/screenshots/ScreenshotsApi.java
+++ b/src/main/java/com/crowdin/client/screenshots/ScreenshotsApi.java
@@ -44,9 +44,12 @@ public class ScreenshotsApi extends CrowdinApi {
      * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.screenshots.getMany" target="_blank"><b>Enterprise API Documentation</b></a></li>
      * </ul>
      */
-    public ResponseList<Screenshot> listScreenshots(Long projectId, Long stringId, Integer limit, Integer offset) throws HttpException, HttpBadRequestException {
+    public ResponseList<Screenshot> listScreenshots(Long projectId,@Deprecated Long stringId ,List<String> stringIds,List<String> labelIds,List<String> excludeLabelIds, Integer limit, Integer offset) throws HttpException, HttpBadRequestException {
         Map<String, Optional<Object>> queryParams = HttpRequestConfig.buildUrlParams(
                 "stringId", Optional.ofNullable(stringId),
+                "stringIds", Optional.ofNullable(stringIds),
+                "labelIds", Optional.ofNullable(labelIds),
+                "excludeLabelIds", Optional.ofNullable(excludeLabelIds),
                 "limit", Optional.ofNullable(limit),
                 "offset", Optional.ofNullable(offset)
         );

--- a/src/test/java/com/crowdin/client/screenshots/ScreenshotsApiTest.java
+++ b/src/test/java/com/crowdin/client/screenshots/ScreenshotsApiTest.java
@@ -64,6 +64,13 @@ public class ScreenshotsApiTest extends TestClient {
     }
 
     @Test
+    public void newListScreenshotsTest() {
+        ResponseList<Screenshot> screenshotResponseList = this.getScreenshotsApi().listScreenshots(projectId, null, null, null, null, null);
+        assertEquals(screenshotResponseList.getData().size(), 1);
+        assertEquals(screenshotResponseList.getData().get(0).getData().getId(), screenshotId);
+    }
+
+    @Test
     public void addScreenshotTest() {
         AddScreenshotRequest request = new AddScreenshotRequest();
         request.setName(name);


### PR DESCRIPTION
I have carefully reviewed the documentation and have added the `stringIds`, `labelIds`, and `excludeLabelIds` parameters to the `ScreenshotsApi.listScreenshots` method. Additionally, I have marked the `stringId` parameter as deprecated.