### PR TITLE
feat(projects):`defaultTmId`, `defaultGlossaryId` support

### DIFF
--- a/src/main/java/com/crowdin/client/projectsgroups/model/EnterpriseProjectRequest.java
+++ b/src/main/java/com/crowdin/client/projectsgroups/model/EnterpriseProjectRequest.java
@@ -46,4 +46,6 @@ public class EnterpriseProjectRequest extends AddProjectRequest {
     private Boolean glossaryAccess;
     private NotificationSettings notificationSettings;
     private TmPenalties tmPenalties;
+    private Integer defaultTmId;
+    private Integer defaultGlossaryId;
 }

--- a/src/main/java/com/crowdin/client/projectsgroups/model/FilesBasedProjectRequest.java
+++ b/src/main/java/com/crowdin/client/projectsgroups/model/FilesBasedProjectRequest.java
@@ -42,5 +42,7 @@ public class FilesBasedProjectRequest extends AddProjectRequest {
     private Boolean glossaryAccess;
     private TmPenalties tmPenalties;
     private TmContextType tmContextType;
+    private Integer defaultTmId;
+    private Integer defaultGlossaryId;
 
 }

--- a/src/main/java/com/crowdin/client/projectsgroups/model/Project.java
+++ b/src/main/java/com/crowdin/client/projectsgroups/model/Project.java
@@ -33,7 +33,5 @@ public class Project {
     private Language sourceLanguage;
     private List<Language> targetLanguages;
     private String webUrl;
-    private Integer defaultTmId;
-    private Integer defaultGlossaryId;
 
 }

--- a/src/main/java/com/crowdin/client/projectsgroups/model/Project.java
+++ b/src/main/java/com/crowdin/client/projectsgroups/model/Project.java
@@ -33,5 +33,7 @@ public class Project {
     private Language sourceLanguage;
     private List<Language> targetLanguages;
     private String webUrl;
+    private Integer defaultTmId;
+    private Integer defaultGlossaryId;
 
 }

--- a/src/main/java/com/crowdin/client/projectsgroups/model/StringsBasedProjectRequest.java
+++ b/src/main/java/com/crowdin/client/projectsgroups/model/StringsBasedProjectRequest.java
@@ -39,4 +39,6 @@ public class StringsBasedProjectRequest extends AddProjectRequest {
     private TmPenalties tmPenalties;
     private Boolean normalizePlaceholder;
     private TmContextType tmContextType;
+    private Integer defaultTmId;
+    private Integer defaultGlossaryId;
 }


### PR DESCRIPTION
In the request and response parameters of the `add project`, `edit project`, and `get project` interfaces, the newly added `defaultTmId` and `defaultGlossaryId` have been added to support the latest methods. 

What puzzles me is that the [Get Project API documentation](https://support.crowdin.com/developer/api/v2/string-based/?_gl=1*gd56k5*_up*MQ..*_ga*MTAyMjc4NjIxOC4xNzI2NTkzNTYy*_ga_SRNRQ29Q3E*MTcyNjU5MzU2Mi4xLjAuMTcyNjU5MzU2Mi4wLjAuMTAzMjE3NjEzMQ..#tag/Projects/operation/api.projects.get) does not show `defaultTmId` and `defaultGlossaryId` in the parameters. Is it possible that I have misunderstood the requirements?