### PR TITLE
feat: add support for defaultTmId and defaultGlossaryId

### DIFF
--- a/src/main/java/com/crowdin/client/projectsgroups/model/EnterpriseProjectRequest.java
+++ b/src/main/java/com/crowdin/client/projectsgroups/model/EnterpriseProjectRequest.java
@@ -46,4 +46,6 @@ public class EnterpriseProjectRequest extends AddProjectRequest {
     private Boolean glossaryAccess;
     private NotificationSettings notificationSettings;
     private TmPenalties tmPenalties;
+    private Integer defaultTmId;
+    private Integer defaultGlossaryId;
 }

--- a/src/main/java/com/crowdin/client/projectsgroups/model/FilesBasedProjectRequest.java
+++ b/src/main/java/com/crowdin/client/projectsgroups/model/FilesBasedProjectRequest.java
@@ -42,5 +42,7 @@ public class FilesBasedProjectRequest extends AddProjectRequest {
     private Boolean glossaryAccess;
     private TmPenalties tmPenalties;
     private TmContextType tmContextType;
+    private Integer defaultTmId;
+    private Integer defaultGlossaryId;
 
 }

--- a/src/main/java/com/crowdin/client/projectsgroups/model/Project.java
+++ b/src/main/java/com/crowdin/client/projectsgroups/model/Project.java
@@ -33,7 +33,5 @@ public class Project {
     private Language sourceLanguage;
     private List<Language> targetLanguages;
     private String webUrl;
-    private Integer defaultTmId;
-    private Integer defaultGlossaryId;
 
 }

--- a/src/main/java/com/crowdin/client/projectsgroups/model/Project.java
+++ b/src/main/java/com/crowdin/client/projectsgroups/model/Project.java
@@ -33,5 +33,7 @@ public class Project {
     private Language sourceLanguage;
     private List<Language> targetLanguages;
     private String webUrl;
+    private Integer defaultTmId;
+    private Integer defaultGlossaryId;
 
 }

--- a/src/main/java/com/crowdin/client/projectsgroups/model/StringsBasedProjectRequest.java
+++ b/src/main/java/com/crowdin/client/projectsgroups/model/StringsBasedProjectRequest.java
@@ -39,4 +39,6 @@ public class StringsBasedProjectRequest extends AddProjectRequest {
     private TmPenalties tmPenalties;
     private Boolean normalizePlaceholder;
     private TmContextType tmContextType;
+    private Integer defaultTmId;
+    private Integer defaultGlossaryId;
 }


### PR DESCRIPTION
In the request and response parameters of the add project, edit project, and get project interfaces, the newly added defaultTmId and defaultGlossaryId have been added to support the latest methods.