### PR TITLE
fix: Event 'from' not working with 'addWebhook'

### DIFF
--- a/src/main/java/com/crowdin/client/webhooks/model/Event.java
+++ b/src/main/java/com/crowdin/client/webhooks/model/Event.java
@@ -6,7 +6,19 @@ public enum Event implements EnumConverter<Event> {
     FILE_TRANSLATED, FILE_APPROVED, PROJECT_TRANSLATED, PROJECT_APPROVED, TRANSLATION_UPDATED,
     SUGGESTION_ADDED, SUGGESTION_UPDATED, SUGGESTION_DELETED, SUGGESTION_APPROVED, SUGGESTION_DISAPPROVED,
     FILE_ADDED, FILE_UPDATED, FILE_REVERTED, FILE_DELETED, STRING_ADDED, STRING_UPDATED, STRING_DELETED,
-    STRINGCOMMENT_CREATED, STRINGCOMMENT_UPDATED, STRINGCOMMENT_DELETED, STRINGCOMMENT_RESTORED, TASK_ADDED, TASK_STATUSCHANGED, TASK_DELETED;
+    STRINGCOMMENT_CREATED("stringComment.created"), STRINGCOMMENT_UPDATED("stringComment.updated"),
+    STRINGCOMMENT_DELETED("stringComment.deleted"), STRINGCOMMENT_RESTORED("stringComment.restored"),
+    TASK_ADDED, TASK_STATUSCHANGED("task.statusChanged"), TASK_DELETED;
+
+    final String rawName;
+
+    Event() {
+        rawName = name().toLowerCase().replace("_", ".");
+    }
+
+    Event(String rawName) {
+        this.rawName = rawName;
+    }
 
     public static Event from(String value) {
         return Event.valueOf(value.toUpperCase().replace(".", "_"));
@@ -14,6 +26,6 @@ public enum Event implements EnumConverter<Event> {
 
     @Override
     public Object to(Event v) {
-        return v.name().toLowerCase().replace("_", ".");
+        return rawName;
     }
 }

--- a/src/test/java/com/crowdin/client/webhooks/WebhooksApiTest.java
+++ b/src/test/java/com/crowdin/client/webhooks/WebhooksApiTest.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,6 +37,7 @@ public class WebhooksApiTest extends TestClient {
         return Arrays.asList(
                 RequestMock.build(this.url + "/projects/" + projectId + "/webhooks", HttpGet.METHOD_NAME, "api/webhooks/listWebhooks.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/webhooks", HttpPost.METHOD_NAME, "api/webhooks/addWebhookRequest.json", "api/webhooks/webhook.json"),
+                RequestMock.build(this.url + "/projects/" + projectId + "/webhooks", HttpPost.METHOD_NAME, "api/webhooks/addWebhookRequestRawEvent.json", "api/webhooks/webhookRawEvent.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/webhooks/" + webhookId, HttpGet.METHOD_NAME, "api/webhooks/webhook.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/webhooks/" + webhookId, HttpDelete.METHOD_NAME),
                 RequestMock.build(this.url + "/projects/" + projectId + "/webhooks/" + webhookId, HttpPatch.METHOD_NAME, "api/webhooks/editWebhook.json", "api/webhooks/webhook.json")
@@ -63,6 +66,23 @@ public class WebhooksApiTest extends TestClient {
         ResponseObject<Webhook> webhookResponseObject = this.getWebhooksApi().addWebhook(projectId, request);
         assertEquals(webhookResponseObject.getData().getId(), webhookId);
         assertEquals(webhookResponseObject.getData().getName(), name);
+    }
+
+    @Test
+    public void addWebhookRawEventTest() {
+        AddWebhookRequest request = new AddWebhookRequest();
+        List<Event> events = Stream.of("stringComment.created").map(Event::from).collect(Collectors.toList());
+        request.setName(name);
+        request.setUrl("test.com");
+        request.setEvents(events);
+        request.setRequestType(RequestType.POST);
+        request.setIsActive(true);
+        request.setBatchingEnabled(batchingEnabled);
+        request.setContentType(ContentType.MULTIPART_FORM_DATA);
+        ResponseObject<Webhook> webhookResponseObject = this.getWebhooksApi().addWebhook(projectId, request);
+        assertEquals(webhookResponseObject.getData().getId(), webhookId);
+        assertEquals(webhookResponseObject.getData().getName(), name);
+        assertEquals(events, webhookResponseObject.getData().getEvents());
     }
 
     @Test

--- a/src/test/java/com/crowdin/client/webhooks/WebhooksModelTest.java
+++ b/src/test/java/com/crowdin/client/webhooks/WebhooksModelTest.java
@@ -1,0 +1,17 @@
+package com.crowdin.client.webhooks;
+
+import com.crowdin.client.webhooks.model.Event;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class WebhooksModelTest {
+
+    @Test
+    public void testEventConversion() {
+        for (Event event : Event.values()) {
+            String raw = (String) event.to(event);
+            assertEquals(event, Event.from(raw));
+        }
+    }
+}

--- a/src/test/resources/api/webhooks/addWebhookRequestRawEvent.json
+++ b/src/test/resources/api/webhooks/addWebhookRequestRawEvent.json
@@ -1,0 +1,11 @@
+{
+  "name": "Proofread",
+  "url": "test.com",
+  "events": [
+    "stringComment.created"
+  ],
+  "requestType": "POST",
+  "isActive": true,
+  "batchingEnabled": false,
+  "contentType": "multipart/form-data"
+}

--- a/src/test/resources/api/webhooks/webhookRawEvent.json
+++ b/src/test/resources/api/webhooks/webhookRawEvent.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "id": 4,
+    "projectId": 2,
+    "name": "Proofread",
+    "url": "https://webhook.site/1c20d9b5-6e6a-4522-974d-9da7ea7595c9",
+    "events": [
+      "stringComment.created"
+    ],
+    "headers": {
+      "string": "string"
+    },
+    "payload": [
+      "string"
+    ],
+    "isActive": true,
+    "requestType": "GET",
+    "batchingEnabled": false,
+    "contentType": "multipart/form-data",
+    "createdAt": "2019-09-23T09:19:07+00:00",
+    "updatedAt": "2019-09-23T09:19:07+00:00"
+  }
+}


### PR DESCRIPTION
Looks like issue #224 is related to bunch of events that have composite names in their String representation, like 'stringComment.created' or ''task.statusChanged". When converted back to String from enum instance it becomes "stringcomment.created" which no longer matches the original spelling of the event's name.

The provided solution adds ability to specify String representation for enum instance where it's necessary for further conversions.