### PR TITLE
feat: add updateOption field to UploadStringsRequest

### DIFF
--- a/src/main/java/com/crowdin/client/sourcestrings/model/UploadStringsProgress.java
+++ b/src/main/java/com/crowdin/client/sourcestrings/model/UploadStringsProgress.java
@@ -1,6 +1,7 @@
 package com.crowdin.client.sourcestrings.model;
 
 import com.crowdin.client.core.http.impl.json.EmptyArrayToNullDeserializer;
+import com.crowdin.client.sourcefiles.model.UpdateOption;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Data;
 
@@ -29,5 +30,7 @@ public class UploadStringsProgress {
         private List<Long> labelIds;
         @JsonDeserialize(using = EmptyArrayToNullDeserializer.class)
         private ImportOptions importOptions;
+        private Boolean updateStrings;
+        private UpdateOption updateOption;
     }
 }

--- a/src/main/java/com/crowdin/client/sourcestrings/model/UploadStringsRequest.java
+++ b/src/main/java/com/crowdin/client/sourcestrings/model/UploadStringsRequest.java
@@ -1,5 +1,6 @@
 package com.crowdin.client.sourcestrings.model;
 
+import com.crowdin.client.sourcefiles.model.UpdateOption;
 import lombok.Data;
 
 import java.util.List;
@@ -15,4 +16,19 @@ public class UploadStringsRequest {
     private Boolean updateStrings;
     private Boolean cleanupMode;
     private ImportOptions importOptions;
+    private UpdateOption updateOption;
+
+    public void setUpdateStrings(Boolean updateStrings) {
+        this.updateStrings = updateStrings;
+        if (updateStrings) {
+            this.updateOption = UpdateOption.CLEAR_TRANSLATIONS_AND_APPROVALS;
+        }
+    }
+
+    public void setUpdateOption(UpdateOption updateOption) {
+        this.updateOption = updateOption;
+        if (!Boolean.TRUE.equals(this.updateStrings)) {
+            this.updateStrings = true;
+        }
+    }
 }

--- a/src/test/java/com/crowdin/client/sourcestrings/SourceStringsApiTest.java
+++ b/src/test/java/com/crowdin/client/sourcestrings/SourceStringsApiTest.java
@@ -7,6 +7,7 @@ import com.crowdin.client.core.model.ResponseList;
 import com.crowdin.client.core.model.ResponseObject;
 import com.crowdin.client.framework.RequestMock;
 import com.crowdin.client.framework.TestClient;
+import com.crowdin.client.sourcefiles.model.UpdateOption;
 import com.crowdin.client.sourcestrings.model.*;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
@@ -21,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SourceStringsApiTest extends TestClient {
 
@@ -65,10 +67,17 @@ public class SourceStringsApiTest extends TestClient {
         request.setBranchId(branchId);
         request.setStorageId(storageId);
         request.setLabelIds(singletonList(labelId));
+        request.setUpdateStrings(true);
+        request.setUpdateOption(UpdateOption.KEEP_TRANSLATIONS);
         ResponseObject<UploadStringsProgress> uploadStringsProgressResponseObject = this.getSourceStringsApi().uploadStrings(projectId, request);
         assertEquals(uploadStringsProgressResponseObject.getData().getIdentifier(), uploadId);
         assertEquals(uploadStringsProgressResponseObject.getData().getAttributes().getBranchId(), branchId);
         assertEquals(uploadStringsProgressResponseObject.getData().getAttributes().getLabelIds().get(0), labelId);
+        assertTrue(uploadStringsProgressResponseObject.getData().getAttributes().getUpdateStrings());
+        assertEquals(
+            UpdateOption.KEEP_TRANSLATIONS,
+            uploadStringsProgressResponseObject.getData().getAttributes().getUpdateOption()
+        );
     }
 
     @Test

--- a/src/test/java/com/crowdin/client/sourcestrings/model/UploadStringsRequestTest.java
+++ b/src/test/java/com/crowdin/client/sourcestrings/model/UploadStringsRequestTest.java
@@ -1,0 +1,56 @@
+package com.crowdin.client.sourcestrings.model;
+
+import com.crowdin.client.sourcefiles.model.UpdateOption;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UploadStringsRequestTest {
+
+    private final UpdateOption defaultOption = UpdateOption.CLEAR_TRANSLATIONS_AND_APPROVALS;
+
+    @Test
+    public void updateStringsTest() {
+        boolean isUpdateStrings = true;
+        UpdateOption updateOption = UpdateOption.KEEP_TRANSLATIONS;
+
+        UploadStringsRequest request = new UploadStringsRequest();
+        request.setUpdateStrings(isUpdateStrings);
+        request.setUpdateOption(updateOption);
+
+        assertEquals(isUpdateStrings, request.getUpdateStrings());
+        assertEquals(updateOption, request.getUpdateOption());
+    }
+
+    @Test
+    public void defaultUpdateOptionTest() {
+        UploadStringsRequest request = new UploadStringsRequest();
+        request.setUpdateStrings(true);
+
+        assertEquals(defaultOption, request.getUpdateOption());
+    }
+
+    @Test
+    public void updateStringsFlagDisabledTest() {
+        UploadStringsRequest request = new UploadStringsRequest();
+        request.setUpdateStrings(false);
+
+        assertFalse(request.getUpdateStrings());
+        assertNull(request.getUpdateOption());
+    }
+
+    @Test
+    public void updateStringsFlagShouldBeEnabledTest() {
+        UpdateOption updateOption = UpdateOption.KEEP_TRANSLATIONS_AND_APPROVALS;
+
+        UploadStringsRequest request = new UploadStringsRequest();
+        request.setUpdateOption(updateOption);
+
+        assertTrue(request.getUpdateStrings());
+        assertEquals(updateOption, request.getUpdateOption());
+    }
+
+}

--- a/src/test/resources/api/strings/uploadStrings.json
+++ b/src/test/resources/api/strings/uploadStrings.json
@@ -21,7 +21,8 @@
           "de": 3
         }
       },
-      "updateStrings": false,
+      "updateStrings": true,
+      "updateOption": "keep_translations",
       "cleanupMode": false
     },
     "createdAt": "2019-09-23T11:26:54+00:00",

--- a/src/test/resources/api/strings/uploadStringsReq.json
+++ b/src/test/resources/api/strings/uploadStringsReq.json
@@ -3,5 +3,7 @@
   "branchId": 667,
   "labelIds": [
     1
-  ]
+  ],
+  "updateStrings": true,
+  "updateOption": "keep_translations"
 }


### PR DESCRIPTION
* Added `updateOption` field to strings upload request and progress response according to API Reference docs.
* Covered logic with tests.

Covers #260.