### PR TITLE
feat: add support for the list and edit pre-translation API endpoints

### DIFF
--- a/src/main/java/com/crowdin/client/translations/TranslationsApi.java
+++ b/src/main/java/com/crowdin/client/translations/TranslationsApi.java
@@ -264,7 +264,7 @@ public class TranslationsApi extends CrowdinApi {
                 "limit", Optional.ofNullable(limit),
                 "offset", Optional.ofNullable(offset)
         );
-        PreTranslationResponseList preTranslationStatusResponseList = this.httpClient.get(this.url + "/projects/" + projectId + "/pre-translations/", new HttpRequestConfig(queryParams), PreTranslationResponseList.class);
+        PreTranslationResponseList preTranslationStatusResponseList = this.httpClient.get(this.url + "/projects/" + projectId + "/pre-translations", new HttpRequestConfig(queryParams), PreTranslationResponseList.class);
         return PreTranslationResponseList.to(preTranslationStatusResponseList);
     }
 

--- a/src/main/java/com/crowdin/client/translations/TranslationsApi.java
+++ b/src/main/java/com/crowdin/client/translations/TranslationsApi.java
@@ -8,6 +8,7 @@ import com.crowdin.client.core.model.ClientConfig;
 import com.crowdin.client.core.model.Credentials;
 import com.crowdin.client.core.model.DownloadLink;
 import com.crowdin.client.core.model.DownloadLinkResponseObject;
+import com.crowdin.client.core.model.PatchRequest;
 import com.crowdin.client.core.model.ResponseList;
 import com.crowdin.client.core.model.ResponseObject;
 import com.crowdin.client.translations.model.ApplyPreTranslationRequest;
@@ -18,6 +19,7 @@ import com.crowdin.client.translations.model.BuildProjectTranslationRequest;
 import com.crowdin.client.translations.model.ExportProjectTranslationRequest;
 import com.crowdin.client.translations.model.PreTranslation;
 import com.crowdin.client.translations.model.PreTranslationResponseList;
+import com.crowdin.client.translations.model.PreTranslationResponseObject;
 import com.crowdin.client.translations.model.PreTranslationStatus;
 import com.crowdin.client.translations.model.PreTranslationStatusResponseObject;
 import com.crowdin.client.translations.model.ProjectBuild;
@@ -32,6 +34,7 @@ import com.crowdin.client.translations.model.UploadTranslationsStringsResponseOb
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -261,7 +264,27 @@ public class TranslationsApi extends CrowdinApi {
                 "limit", Optional.ofNullable(limit),
                 "offset", Optional.ofNullable(offset)
         );
-        PreTranslationResponseList preTranslationStatusResponseObject = this.httpClient.get(this.url + "/projects/" + projectId + "/pre-translations/", new HttpRequestConfig(queryParams), PreTranslationResponseList.class);
-        return PreTranslationResponseList.to(preTranslationStatusResponseObject);
+        PreTranslationResponseList preTranslationStatusResponseList = this.httpClient.get(this.url + "/projects/" + projectId + "/pre-translations/", new HttpRequestConfig(queryParams), PreTranslationResponseList.class);
+        return PreTranslationResponseList.to(preTranslationStatusResponseList);
+    }
+
+    /**
+     * Edit Pre-Translations
+     *
+     * @param projectId project identifier
+     * @param preTranslationId pre-translation identifier
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.projects.pre-translations.patch" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.pre-translations.patch" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseObject<PreTranslation> editPreTranslation(Long projectId, String preTranslationId, List<PatchRequest> request) throws HttpException, HttpBadRequestException {
+        PreTranslationResponseObject preTranslationStatusResponseObject = this.httpClient.patch(
+                this.url + "/projects/" + projectId + "/pre-translations/" + preTranslationId,
+                request,
+                new HttpRequestConfig(),
+                PreTranslationResponseObject.class
+        );
+        return ResponseObject.of(preTranslationStatusResponseObject.getData());
     }
 }

--- a/src/main/java/com/crowdin/client/translations/TranslationsApi.java
+++ b/src/main/java/com/crowdin/client/translations/TranslationsApi.java
@@ -264,12 +264,12 @@ public class TranslationsApi extends CrowdinApi {
                 "limit", Optional.ofNullable(limit),
                 "offset", Optional.ofNullable(offset)
         );
-        PreTranslationResponseList preTranslationStatusResponseList = this.httpClient.get(this.url + "/projects/" + projectId + "/pre-translations", new HttpRequestConfig(queryParams), PreTranslationResponseList.class);
-        return PreTranslationResponseList.to(preTranslationStatusResponseList);
+        PreTranslationResponseList preTranslationResponseList = this.httpClient.get(this.url + "/projects/" + projectId + "/pre-translations", new HttpRequestConfig(queryParams), PreTranslationResponseList.class);
+        return PreTranslationResponseList.to(preTranslationResponseList);
     }
 
     /**
-     * Edit Pre-Translations
+     * Edit Pre-Translation
      *
      * @param projectId project identifier
      * @param preTranslationId pre-translation identifier
@@ -279,12 +279,12 @@ public class TranslationsApi extends CrowdinApi {
      * </ul>
      */
     public ResponseObject<PreTranslation> editPreTranslation(Long projectId, String preTranslationId, List<PatchRequest> request) throws HttpException, HttpBadRequestException {
-        PreTranslationResponseObject preTranslationStatusResponseObject = this.httpClient.patch(
+        PreTranslationResponseObject preTranslationResponseObject = this.httpClient.patch(
                 this.url + "/projects/" + projectId + "/pre-translations/" + preTranslationId,
                 request,
                 new HttpRequestConfig(),
                 PreTranslationResponseObject.class
         );
-        return ResponseObject.of(preTranslationStatusResponseObject.getData());
+        return ResponseObject.of(preTranslationResponseObject.getData());
     }
 }

--- a/src/main/java/com/crowdin/client/translations/TranslationsApi.java
+++ b/src/main/java/com/crowdin/client/translations/TranslationsApi.java
@@ -16,6 +16,8 @@ import com.crowdin.client.translations.model.BuildProjectDirectoryTranslationReq
 import com.crowdin.client.translations.model.BuildProjectFileTranslationRequest;
 import com.crowdin.client.translations.model.BuildProjectTranslationRequest;
 import com.crowdin.client.translations.model.ExportProjectTranslationRequest;
+import com.crowdin.client.translations.model.PreTranslation;
+import com.crowdin.client.translations.model.PreTranslationResponseList;
 import com.crowdin.client.translations.model.PreTranslationStatus;
 import com.crowdin.client.translations.model.PreTranslationStatusResponseObject;
 import com.crowdin.client.translations.model.ProjectBuild;
@@ -241,5 +243,25 @@ public class TranslationsApi extends CrowdinApi {
         String builtUrl = String.format("%s/projects/%d/translations/exports", this.url, projectId);
         DownloadLinkResponseObject response = this.httpClient.post(builtUrl, request, new HttpRequestConfig(), DownloadLinkResponseObject.class);
         return ResponseObject.of(response.getData());
+    }
+
+    /**
+     * List Pre-Translations
+     *
+     * @param projectId project identifier
+     * @param limit maximum number of items to retrieve (default 25)
+     * @param offset starting offset in the collection (default 0)
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.projects.pre-translations.getMany" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.pre-translations.getMany" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseList<PreTranslation> listPreTranslations(Long projectId, Integer limit, Integer offset) throws HttpException, HttpBadRequestException {
+        Map<String, Optional<Object>> queryParams = HttpRequestConfig.buildUrlParams(
+                "limit", Optional.ofNullable(limit),
+                "offset", Optional.ofNullable(offset)
+        );
+        PreTranslationResponseList preTranslationStatusResponseObject = this.httpClient.get(this.url + "/projects/" + projectId + "/pre-translations/", new HttpRequestConfig(queryParams), PreTranslationResponseList.class);
+        return PreTranslationResponseList.to(preTranslationStatusResponseObject);
     }
 }

--- a/src/main/java/com/crowdin/client/translations/model/PreTranslation.java
+++ b/src/main/java/com/crowdin/client/translations/model/PreTranslation.java
@@ -1,0 +1,59 @@
+package com.crowdin.client.translations.model;
+
+import com.crowdin.client.core.model.EnumConverter;
+import lombok.Data;
+
+import java.util.Date;
+import java.util.List;
+
+@Data
+public class PreTranslation {
+    private String identifier;
+    private Status status;
+    private Integer progress;
+    private Attributes attributes;
+    private Date createdAt;
+    private Date updatedAt;
+    private String startedAt;
+    private String finishedAt;
+
+    @Data
+    public static class Attributes {
+        private List<String> languageIds;
+        private List<Integer> fileIds;
+        private String method;
+        private String autoApproveOption;
+        private Boolean duplicateTranslations;
+        private Boolean skipApprovedTranslations;
+        private Boolean translateUntranslatedOnly;
+        private Boolean translateWithPerfectMatchOnly;
+    }
+
+    public enum Status implements EnumConverter<Status> {
+        CREATED("created"),
+        IN_PROGRESS("in_progress"),
+        CANCELED("canceled"),
+        FAILED("failed"),
+        FINISHED("finished");
+
+        private String value;
+
+        Status(String value) {
+            this.value = value;
+        }
+
+        public static Status from(String value) {
+            for (Status s : Status.values()) {
+                if (s.value.equals(value)) {
+                    return s;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public Object to(Status v) {
+            return this.value;
+        }
+    }
+}

--- a/src/main/java/com/crowdin/client/translations/model/PreTranslation.java
+++ b/src/main/java/com/crowdin/client/translations/model/PreTranslation.java
@@ -20,7 +20,7 @@ public class PreTranslation {
     @Data
     public static class Attributes {
         private List<String> languageIds;
-        private List<Integer> fileIds;
+        private List<Long> fileIds;
         private String method;
         private String autoApproveOption;
         private Boolean duplicateTranslations;

--- a/src/main/java/com/crowdin/client/translations/model/PreTranslationResponseList.java
+++ b/src/main/java/com/crowdin/client/translations/model/PreTranslationResponseList.java
@@ -1,0 +1,25 @@
+package com.crowdin.client.translations.model;
+
+import com.crowdin.client.core.model.Pagination;
+import com.crowdin.client.core.model.ResponseList;
+import com.crowdin.client.core.model.ResponseObject;
+import lombok.Data;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+public class PreTranslationResponseList {
+    private List<PreTranslationResponseObject> data;
+    private Pagination pagination;
+
+    public static ResponseList<PreTranslation> to(PreTranslationResponseList preTranslationResponseList) {
+        return ResponseList.of(
+                preTranslationResponseList.getData().stream()
+                        .map(PreTranslationResponseObject::getData)
+                        .map(ResponseObject::of)
+                        .collect(Collectors.toList()),
+                preTranslationResponseList.getPagination()
+        );
+    }
+}

--- a/src/main/java/com/crowdin/client/translations/model/PreTranslationResponseObject.java
+++ b/src/main/java/com/crowdin/client/translations/model/PreTranslationResponseObject.java
@@ -1,0 +1,8 @@
+package com.crowdin.client.translations.model;
+
+import lombok.Data;
+
+@Data
+public class PreTranslationResponseObject {
+    private PreTranslation data;
+}

--- a/src/test/resources/api/translations/editPreTranslationRequest.json
+++ b/src/test/resources/api/translations/editPreTranslationRequest.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "/status",
+    "value": "cancelled"
+  }
+]

--- a/src/test/resources/api/translations/editPreTranslationResponse.json
+++ b/src/test/resources/api/translations/editPreTranslationResponse.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "identifier": "9e7de270-4f83-41cb-b606-2f90631f26e2",
+    "status": "cancelled",
+    "progress": 50,
+    "attributes": {
+      "method": "tm",
+      "fileIds": [
+        2
+      ],
+      "languageIds": [
+        "uk"
+      ],
+      "autoApproveOption": "none",
+      "fallbackLanguages": null,
+      "duplicateTranslations": false,
+      "skipApprovedTranslations": false,
+      "translateUntranslatedOnly": true,
+      "translateWithPerfectMatchOnly": false
+    },
+    "createdAt": "2024-01-01T01:00:00+00:00",
+    "updatedAt": "2024-01-01T01:01:00+00:00",
+    "startedAt": "2024-01-01T01:00:00+00:00",
+    "finishedAt": "2024-01-01T01:01:00+00:00"
+  }
+}

--- a/src/test/resources/api/translations/listPreTranslations.json
+++ b/src/test/resources/api/translations/listPreTranslations.json
@@ -1,0 +1,34 @@
+{
+  "data": [
+    {
+      "data": {
+        "identifier": "9e7de270-4f83-41cb-b606-2f90631f26e2",
+        "status": "finished",
+        "progress": 100,
+        "attributes": {
+          "method": "tm",
+          "fileIds": [
+            2
+          ],
+          "languageIds": [
+            "uk"
+          ],
+          "autoApproveOption": "none",
+          "fallbackLanguages": null,
+          "duplicateTranslations": false,
+          "skipApprovedTranslations": false,
+          "translateUntranslatedOnly": true,
+          "translateWithPerfectMatchOnly": false
+        },
+        "createdAt": "2024-01-01T01:00:00+00:00",
+        "updatedAt": "2024-01-01T01:01:00+00:00",
+        "startedAt": "2024-01-01T01:00:00+00:00",
+        "finishedAt": "2024-01-01T01:01:00+00:00"
+      }
+    }
+  ],
+  "pagination": {
+    "offset": 0,
+    "limit": 100
+  }
+}


### PR DESCRIPTION
Added methods for new pre-translation API endpoints:
* listPreTranslations for [List Pre-Translations](https://support.crowdin.com/developer/api/v2/#tag/Translations/operation/api.projects.pre-translations.getMany)
* editPreTranslation for [Edit Pre-Translation](https://support.crowdin.com/developer/api/v2/#tag/Translations/operation/api.projects.pre-translations.patch)

Closes #266 
