### PR TITLE
feat: Add Remove String Approvals API and update Delete String Translations API

### DIFF
--- a/src/main/java/com/crowdin/client/stringtranslations/StringTranslationsApi.java
+++ b/src/main/java/com/crowdin/client/stringtranslations/StringTranslationsApi.java
@@ -193,7 +193,7 @@ public class StringTranslationsApi extends CrowdinApi {
                 "stringId", Optional.ofNullable(stringId),
                 "languageId", Optional.ofNullable(languageId)
         );
-        this.httpClient.get(this.url + "/projects/" + projectId + "/translations", new HttpRequestConfig(queryParams), Void.class);
+        this.httpClient.delete(this.url + "/projects/" + projectId + "/translations", new HttpRequestConfig(queryParams), Void.class);
     }
 
     /**
@@ -218,8 +218,8 @@ public class StringTranslationsApi extends CrowdinApi {
      * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.translations.delete" target="_blank"><b>Enterprise API Documentation</b></a></li>
      * </ul>
      */
-    public void deleteStringTranslation(Long projectId, Long translationId) throws HttpException, HttpBadRequestException {
-        this.httpClient.delete(this.url + "/projects/" + projectId + "/translations/" + translationId, new HttpRequestConfig(), Void.class);
+    public void deleteStringTranslations(Long projectId, Long stringId) throws HttpException, HttpBadRequestException {
+        deleteStringTranslations(projectId, stringId, null);
     }
 
     /**


### PR DESCRIPTION
This pull request introduces two new functionalities in the ClientsApi class of the Crowdin API client for Java:

Remove String Approvals:
• Implemented a new method removeStringApprovals that allows users to remove approvals for a specific string within a
project. This change provides a streamlined way to manage string approvals across multiple languages.

>I've made the following changes to enhance the removeStringApprovalsTest:
1. Added a new mock for listing translation approvals.
2. Added a new mock for getting string information.
3. Added an assertion to verify that approvals exist before removal.
4. Added an assertion to verify that approvals are empty after removal.
5. Added assertions to verify that the string still exists after approval removal.
6. Added an assertion to check that removing approvals a second time doesn't throw an exception.