### PR TITLE
feat: Add user report endpoints support

### DIFF
--- a/src/main/java/com/crowdin/client/reports/ReportsApi.java
+++ b/src/main/java/com/crowdin/client/reports/ReportsApi.java
@@ -217,6 +217,87 @@ public class ReportsApi extends CrowdinApi {
         this.httpClient.delete(this.url + "/projects/" + projectId + "/settings-templates/" + reportSettingsTemplateId, new HttpRequestConfig(), Void.class);
     }
 
+    // -- USER REPORTS -- //
+
+    /**
+     *
+     * @param userId user identifier
+     * @param limit (default 25)
+     * @param offset (default 0)
+     * @return list of user report settings template
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.users.reports.settings-templates.getMany" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.users.reports.settings-templates.getMany" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseList<ReportSettingsTemplate> listUserReportSettingsTemplate(Long userId, Integer limit, Integer offset) throws HttpException, HttpBadRequestException {
+        Map<String, Optional<Object>> queryParams = HttpRequestConfig.buildUrlParams(
+                "limit", Optional.ofNullable(limit),
+                "offset", Optional.ofNullable(offset)
+        );
+        ReportSettingsTemplateList reportSettingsTemplateList = this.httpClient.get(this.url + "/users/" + userId + "/reports/settings-templates", new HttpRequestConfig(queryParams), ReportSettingsTemplateList.class);
+        return ReportSettingsTemplateList.to(reportSettingsTemplateList);
+    }
+
+    /**
+     *
+     * @param userId user identifier
+     * @param request request object
+     * @return user report settings template
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.users.reports.settings-templates.post" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.users.reports.settings-templates.post" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseObject<ReportSettingsTemplate> addUserReportSettingsTemplate(Long userId, ReportSettingsTemplate request) throws HttpException, HttpBadRequestException {
+        ReportSettingsTemplateResponseObject responseObject = this.httpClient.post(this.url + "/users/" + userId + "/reports/settings-templates", request, new HttpRequestConfig(), ReportSettingsTemplateResponseObject.class);
+        return ResponseObject.of(responseObject.getData());
+    }
+
+    /**
+     *
+     * @param userId user identifier
+     * @param reportSettingsTemplateId report settings template identifier
+     * @return user report settings template
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.users.reports.settings-templates.get" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.users.reports.settings-templates.get" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseObject<ReportSettingsTemplate> getUserReportSettingsTemplate(Long userId, Long reportSettingsTemplateId) throws HttpException, HttpBadRequestException {
+        ReportSettingsTemplateResponseObject responseObject = this.httpClient.get(this.url + "/users/" + userId + "/reports/settings-templates/" + reportSettingsTemplateId, new HttpRequestConfig(), ReportSettingsTemplateResponseObject.class);
+        return ResponseObject.of(responseObject.getData());
+    }
+
+    /**
+     *
+     * @param userId user identifier
+     * @param reportSettingsTemplateId report settings template identifier
+     * @param request request object
+     * @return user report settings template
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.users.reports.settings-templates.patch" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.users.reports.settings-templates.patch" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseObject<ReportSettingsTemplate> editUserReportSettingsTemplate(Long userId, Long reportSettingsTemplateId, List<PatchRequest> request) throws HttpException, HttpBadRequestException {
+        ReportSettingsTemplateResponseObject responseObject = this.httpClient.patch(this.url + "/users/" + userId + "/reports/settings-templates/" + reportSettingsTemplateId, request, new HttpRequestConfig(), ReportSettingsTemplateResponseObject.class);
+        return ResponseObject.of(responseObject.getData());
+    }
+
+    /**
+     *
+     * @param userId user identifier
+     * @param reportSettingsTemplateId report settings template identifier
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.users.reports.settings-templates.delete" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.users.reports.settings-templates.delete" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public void deleteUserReportSettingsTemplate(Long userId, Long reportSettingsTemplateId) throws HttpException, HttpBadRequestException {
+        this.httpClient.delete(this.url + "/users/" + userId + "/reports/settings-templates/" + reportSettingsTemplateId, new HttpRequestConfig(), Void.class);
+    }
+
     // -- REPORT ARCHIVES -- //
 
     /**

--- a/src/test/java/com/crowdin/client/reports/ReportsApiTest.java
+++ b/src/test/java/com/crowdin/client/reports/ReportsApiTest.java
@@ -72,7 +72,12 @@ public class ReportsApiTest extends TestClient {
                 RequestMock.build(this.url + "/users/" + userId + "/reports/archives/" + archiveId, HttpDelete.METHOD_NAME),
                 RequestMock.build(this.url + "/users/" + userId + "/reports/archives/" + archiveId + "/exports", HttpPost.METHOD_NAME, "api/reports/exportReportArchiveReques.json", "api/reports/reportGenerationStatus.json"),
                 RequestMock.build(this.url + "/users/" + userId + "/reports/archives/" + archiveId + "/exports/" + exportId, HttpGet.METHOD_NAME, "api/reports/reportGenerationStatus.json"),
-                RequestMock.build(this.url + "/users/" + userId + "/reports/archives" + archiveId + "/exports/" + exportId + "/download", HttpGet.METHOD_NAME, "api/reports/downloadLink.json"));
+                RequestMock.build(this.url + "/users/" + userId + "/reports/archives" + archiveId + "/exports/" + exportId + "/download", HttpGet.METHOD_NAME, "api/reports/downloadLink.json"),
+                RequestMock.build(this.url + "/users/" + userId + "/reports/settings-templates", HttpGet.METHOD_NAME, "api/reports/listUserReportSettingsTemplate.json"),
+                RequestMock.build(this.url + "/users/" + userId + "/reports/settings-templates", HttpPost.METHOD_NAME, "api/reports/addUserReportSettingsTemplate.json", "api/reports/userReportSettingsTemplate.json"),
+                RequestMock.build(this.url + "/users/" + userId + "/reports/settings-templates/" + reportSettingsTemplateId, HttpGet.METHOD_NAME, "api/reports/userReportSettingsTemplate.json"),
+                RequestMock.build(this.url + "/users/" + userId + "/reports/settings-templates/" + reportSettingsTemplateId, HttpPatch.METHOD_NAME, "api/reports/editUserReportSettingsTemplate.json", "api/reports/userReportSettingsTemplate.json"),
+                RequestMock.build(this.url + "/users/" + userId + "/reports/settings-templates/" + reportSettingsTemplateId, HttpDelete.METHOD_NAME));
     }
 
     private ReportSettingsTemplate createSettingsTemplate() {
@@ -225,6 +230,49 @@ public class ReportsApiTest extends TestClient {
     @Test
     public void deleteReportSettingsTemplateTest() {
         this.getReportsApi().deleteReportSettingsTemplate(projectId, reportSettingsTemplateId);
+    }
+
+    @Test
+    public void listUserReportSettingsTemplateTest() {
+        ResponseList<ReportSettingsTemplate> userReportSettingsTemplateResponseList = this.getReportsApi().listUserReportSettingsTemplate(userId, null, null);
+        assertEquals(userReportSettingsTemplateResponseList.getData().size(), 1);
+        assertEquals(userReportSettingsTemplateResponseList.getData().get(0).getData().getId(), userId);
+        assertEquals(userReportSettingsTemplateResponseList.getData().get(0).getData().getName(), name);
+    }
+
+    @Test
+    public void addUserReportSettingsTemplateTest() {
+        ReportSettingsTemplate request = createSettingsTemplate();
+        request.setIsPublic(null);
+        ResponseObject<ReportSettingsTemplate> userReportSettingsTemplateResponseObject = this.getReportsApi().addUserReportSettingsTemplate(userId, request);
+        ReportSettingsTemplate response = userReportSettingsTemplateResponseObject.getData();
+        assertEquals(request.getName(), response.getName());
+        assertEquals(request.getCurrency(), response.getCurrency());
+        assertEquals(request.getUnit(), response.getUnit());
+        assertEquals(request.getConfig(), response.getConfig());
+    }
+
+    @Test
+    public void getUserReportSettingsTemplateTest() {
+        ResponseObject<ReportSettingsTemplate> responseObject = this.getReportsApi().getUserReportSettingsTemplate(userId, reportSettingsTemplateId);
+        assertEquals(responseObject.getData().getId(), userId);
+        assertEquals(responseObject.getData().getName(), name);
+    }
+
+    @Test
+    public void editUserReportSettingsTemplateTest() {
+        PatchRequest request = new PatchRequest();
+        request.setOp(PatchOperation.REPLACE);
+        request.setValue(name);
+        request.setPath("name");
+        ResponseObject<ReportSettingsTemplate> responseObject = this.getReportsApi().editUserReportSettingsTemplate(userId, reportSettingsTemplateId, singletonList(request));
+        assertEquals(responseObject.getData().getId(), userId);
+        assertEquals(responseObject.getData().getName(), name);
+    }
+
+    @Test
+    public void deleteUserReportSettingsTemplateTest() {
+        this.getReportsApi().deleteUserReportSettingsTemplate(userId, reportSettingsTemplateId);
     }
 
     @Test

--- a/src/test/resources/api/reports/addUserReportSettingsTemplate.json
+++ b/src/test/resources/api/reports/addUserReportSettingsTemplate.json
@@ -1,0 +1,29 @@
+{
+  "name": "my report template",
+  "currency": "USD",
+  "unit": "strings",
+  "config": {
+    "regularRates": [
+      {
+        "mode": "no_match",
+        "value": 0.1
+      }
+    ],
+    "individualRates": [
+      {
+        "languageIds": [
+          "uk"
+        ],
+        "userIds": [
+          20
+        ],
+        "rates": [
+          {
+            "mode": "tm_match",
+            "value": 0.1
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/test/resources/api/reports/editUserReportSettingsTemplate.json
+++ b/src/test/resources/api/reports/editUserReportSettingsTemplate.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "name",
+    "value": "my report template"
+  }
+]

--- a/src/test/resources/api/reports/listUserReportSettingsTemplate.json
+++ b/src/test/resources/api/reports/listUserReportSettingsTemplate.json
@@ -1,0 +1,40 @@
+{
+  "data": [
+    {
+      "data": {
+        "id": 1,
+        "name": "my report template",
+        "currency": "USD",
+        "unit": "words",
+        "config": {
+          "regularRates": [
+            {
+              "mode": "tm_match",
+              "value": 0.1
+            }
+          ],
+          "individualRates": [
+            {
+              "languageIds": [
+                "uk"
+              ],
+              "userIds": [],
+              "rates": [
+                {
+                  "mode": "tm_match",
+                  "value": 0.1
+                }
+              ]
+            }
+          ]
+        },
+        "createdAt": "2019-09-23T11:26:54+00:00",
+        "updatedAt": "2019-09-23T11:26:54+00:00"
+      }
+    }
+  ],
+  "pagination": {
+    "offset": 0,
+    "limit": 25
+  }
+}

--- a/src/test/resources/api/reports/userReportSettingsTemplate.json
+++ b/src/test/resources/api/reports/userReportSettingsTemplate.json
@@ -1,0 +1,34 @@
+{
+  "data": {
+    "id": 1,
+    "name": "my report template",
+    "currency": "USD",
+    "unit": "strings",
+    "config": {
+      "regularRates": [
+        {
+          "mode": "no_match",
+          "value": 0.1
+        }
+      ],
+      "individualRates": [
+        {
+          "languageIds": [
+            "uk"
+          ],
+          "userIds": [
+            20
+          ],
+          "rates": [
+            {
+              "mode": "tm_match",
+              "value": 0.1
+            }
+          ]
+        }
+      ]
+    },
+    "createdAt": "2019-09-23T11:26:54+00:00",
+    "updatedAt": "2019-09-23T11:26:54+00:00"
+  }
+}


### PR DESCRIPTION
This introduces support for the `User Report Settings Templates` endpoints. For implementation I focused on reusing the existing `Report Settings Templates` logic and made the necessary adjustments to handle the user-specific endpoints.

**Changes**

- Added the methods to support the `User Report Settings Templates` endpoints (`List`, `Add`, `Get`, `Delete`, `Edit`).
- Reused logic from the existing `Report Settings Template` code, with changes to the `URLs` and `parameters`.
- Created 4 new `JSON` files for the `User Report Settings Templates`, structured after the existing `Report Settings Template` files.
- Added test methods to ensure the new functionality works as expected.

**Testing**

- All tests for the added methods pass successfully.
- In case of `Add` test method, I set (in the body of method) the `isPublic` to `null` since is not part of `User Templates`.

**Additional notes**

- I reused the existing code of `Report Settings Template` rather than creating a new class since on the documentation I've noticed that the responses (of each template) are quite similar in structure.
- I've noticed that the `JSONs` associated with `Report Settings Template` were a bit modified in comparison with the documentation, so I structured the `User Report` files based on them.
- I would appreciate any feedback regarding the implementation or any necessary adjustments.