### PR TITLE
feat: Add support to Remove String Approvals endpoint

### DIFF
--- a/src/main/java/com/crowdin/client/stringtranslations/StringTranslationsApi.java
+++ b/src/main/java/com/crowdin/client/stringtranslations/StringTranslationsApi.java
@@ -7,7 +7,6 @@ import com.crowdin.client.core.http.exceptions.HttpException;
 import com.crowdin.client.core.model.*;
 import com.crowdin.client.stringtranslations.model.*;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 

--- a/src/main/java/com/crowdin/client/stringtranslations/StringTranslationsApi.java
+++ b/src/main/java/com/crowdin/client/stringtranslations/StringTranslationsApi.java
@@ -7,6 +7,7 @@ import com.crowdin.client.core.http.exceptions.HttpException;
 import com.crowdin.client.core.model.*;
 import com.crowdin.client.stringtranslations.model.*;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -116,7 +117,7 @@ public class StringTranslationsApi extends CrowdinApi {
      */
     public void removeStringApprovals(Long projectId, Long stringId) throws HttpException, HttpBadRequestException {
         Map<String, Optional<Object>> queryParams = HttpRequestConfig.buildUrlParams(
-                "stringId", Optional.ofNullable(stringId)
+                "stringId", Optional.of(stringId)
         );
         this.httpClient.delete(this.url + "/projects/" + projectId + "/approvals", new HttpRequestConfig(queryParams), Void.class);
     }
@@ -243,10 +244,10 @@ public class StringTranslationsApi extends CrowdinApi {
      */
     public void deleteStringTranslations(Long projectId, Long stringId, String languageId) throws HttpException, HttpBadRequestException {
         Map<String, Optional<Object>> queryParams = HttpRequestConfig.buildUrlParams(
-                "stringId", Optional.ofNullable(stringId),
+                "stringId", Optional.of(stringId),
                 "languageId", Optional.ofNullable(languageId)
         );
-        this.httpClient.get(this.url + "/projects/" + projectId + "/translations", new HttpRequestConfig(queryParams), Void.class);
+        this.httpClient.delete(this.url + "/projects/" + projectId + "/translations", new HttpRequestConfig(queryParams), Void.class);
     }
 
     /**

--- a/src/main/java/com/crowdin/client/stringtranslations/StringTranslationsApi.java
+++ b/src/main/java/com/crowdin/client/stringtranslations/StringTranslationsApi.java
@@ -108,6 +108,21 @@ public class StringTranslationsApi extends CrowdinApi {
 
     /**
      * @param projectId project identifier
+     * @param stringId string identifier
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.projects.approvals.deleteMany" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.approvals.deleteMany" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public void removeStringApprovals(Long projectId, Long stringId) throws HttpException, HttpBadRequestException {
+        Map<String, Optional<Object>> queryParams = HttpRequestConfig.buildUrlParams(
+                "stringId", Optional.ofNullable(stringId)
+        );
+        this.httpClient.delete(this.url + "/projects/" + projectId + "/approvals", new HttpRequestConfig(queryParams), Void.class);
+    }
+
+    /**
+     * @param projectId project identifier
      * @param approvalId approval identifier
      * @see <ul>
      * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.projects.approvals.delete" target="_blank"><b>API Documentation</b></a></li>

--- a/src/test/java/com/crowdin/client/stringtranslations/StringTranslationsApiTest.java
+++ b/src/test/java/com/crowdin/client/stringtranslations/StringTranslationsApiTest.java
@@ -35,6 +35,7 @@ public class StringTranslationsApiTest extends TestClient {
                 RequestMock.build(this.url + "/projects/" + projectId + "/approvals", HttpGet.METHOD_NAME, "api/stringtranslations/listApprovals.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/approvals", HttpPost.METHOD_NAME, "api/stringtranslations/addApprovalRequest.json", "api/stringtranslations/approval.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/approvals/" + approvalId, HttpGet.METHOD_NAME, "api/stringtranslations/approval.json"),
+                RequestMock.build(this.url + "/projects/" + projectId + "/approvals", HttpDelete.METHOD_NAME),
                 RequestMock.build(this.url + "/projects/" + projectId + "/approvals/" + approvalId, HttpDelete.METHOD_NAME),
                 RequestMock.build(String.format("%s/projects/%d/languages/%s/translations", this.url, projectId, language), HttpGet.METHOD_NAME, "api/stringtranslations/listLanguageTranslations_plain.json"),
                 RequestMock.build(String.format("%s/projects/%d/languages/%s/translations", this.url, secondProjectId, language), HttpGet.METHOD_NAME, "api/stringtranslations/listLanguageTranslations_plural.json"),
@@ -84,6 +85,11 @@ public class StringTranslationsApiTest extends TestClient {
     public void getApprovalTest() {
         ResponseObject<Approval> approvalResponseObject = this.getStringTranslationsApi().getApproval(projectId, approvalId);
         assertEquals(approvalResponseObject.getData().getId(), approvalId);
+    }
+
+    @Test
+    public void removeStringApprovalsTest() {
+        this.getStringTranslationsApi().removeStringApprovals(projectId, null);
     }
 
     @Test

--- a/src/test/java/com/crowdin/client/stringtranslations/StringTranslationsApiTest.java
+++ b/src/test/java/com/crowdin/client/stringtranslations/StringTranslationsApiTest.java
@@ -11,8 +11,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -35,14 +34,14 @@ public class StringTranslationsApiTest extends TestClient {
                 RequestMock.build(this.url + "/projects/" + projectId + "/approvals", HttpGet.METHOD_NAME, "api/stringtranslations/listApprovals.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/approvals", HttpPost.METHOD_NAME, "api/stringtranslations/addApprovalRequest.json", "api/stringtranslations/approval.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/approvals/" + approvalId, HttpGet.METHOD_NAME, "api/stringtranslations/approval.json"),
-                RequestMock.build(this.url + "/projects/" + projectId + "/approvals", HttpDelete.METHOD_NAME),
+                RequestMock.build(this.url + "/projects/" + projectId + "/approvals", HttpDelete.METHOD_NAME, null, Collections.singletonMap("stringId", stringId)),
                 RequestMock.build(this.url + "/projects/" + projectId + "/approvals/" + approvalId, HttpDelete.METHOD_NAME),
                 RequestMock.build(String.format("%s/projects/%d/languages/%s/translations", this.url, projectId, language), HttpGet.METHOD_NAME, "api/stringtranslations/listLanguageTranslations_plain.json"),
                 RequestMock.build(String.format("%s/projects/%d/languages/%s/translations", this.url, secondProjectId, language), HttpGet.METHOD_NAME, "api/stringtranslations/listLanguageTranslations_plural.json"),
                 RequestMock.build(String.format("%s/projects/%d/languages/%s/translations", this.url, thirdProjectId, language), HttpGet.METHOD_NAME, "api/stringtranslations/listLanguageTranslations_ICU.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/translations", HttpGet.METHOD_NAME, "api/stringtranslations/listStringTranslations..json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/translations", HttpPost.METHOD_NAME, "api/stringtranslations/addTranslationRequest.json", "api/stringtranslations/translation.json"),
-                RequestMock.build(this.url + "/projects/" + projectId + "/translations", HttpDelete.METHOD_NAME),
+                RequestMock.build(this.url + "/projects/" + projectId + "/translations", HttpDelete.METHOD_NAME, null, Collections.singletonMap("stringId", stringId)),
                 RequestMock.build(this.url + "/projects/" + projectId + "/translations/" + translationId, HttpGet.METHOD_NAME, "api/stringtranslations/translation.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/translations/" + translationId, HttpDelete.METHOD_NAME),
                 RequestMock.build(this.url + "/projects/" + projectId + "/translations/" + translationId, HttpPut.METHOD_NAME, "api/stringtranslations/translation.json"),
@@ -89,7 +88,7 @@ public class StringTranslationsApiTest extends TestClient {
 
     @Test
     public void removeStringApprovalsTest() {
-        this.getStringTranslationsApi().removeStringApprovals(projectId, null);
+        this.getStringTranslationsApi().removeStringApprovals(projectId, stringId);
     }
 
     @Test
@@ -140,7 +139,7 @@ public class StringTranslationsApiTest extends TestClient {
 
     @Test
     public void deleteTranslationsTest() {
-        this.getStringTranslationsApi().deleteStringTranslations(projectId, null, null);
+        this.getStringTranslationsApi().deleteStringTranslations(projectId, stringId, null);
     }
 
     @Test

--- a/src/test/java/com/crowdin/client/stringtranslations/StringTranslationsApiTest.java
+++ b/src/test/java/com/crowdin/client/stringtranslations/StringTranslationsApiTest.java
@@ -11,7 +11,9 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;


### PR DESCRIPTION
<details><summary>Summary</summary>
<p>
Introduces support for the `Remove String Approvals` endpoint and refactors `deleteStringTranslations` method and its corresponding test for better parameter handling.
</p>
</details> 

**Changes**

- Added new method to support the `Remove String Approvals` endpoint.
- Updated the newly added method (`removeStringApprovals`) and the existing one (`deleteStringTranslations`) to fix request type and parameters requirements.
- Changed `HTTP` method from `GET` to `DELETE` for deletion operations.
- Used `Optional.of()` in case of `required parameters` in order to match documentation.

**Testing**

- Added `removeStringApprovalsTest` and refactored `deleteTranslationsTest` to ensure correct functionality.
- Updated the `request mock builders` for the `DELETE` operations to include `query parameters`.
- All tests pass successfully.

**Additional notes**

- The reasoning behind `Optional.of()` is that on the documentation the `stringId` parameter is marked as `required`, so it cannot be `null`.
- Corresponding `request mock builders` used another method from `RequestMock.java`, the one that takes into account the `query params`.
- Any feedback regarding the implementation would be much appreciated!