### PR TITLE
feat: add support for group managers and teams

### DIFF
--- a/src/main/java/com/crowdin/client/teams/TeamsApi.java
+++ b/src/main/java/com/crowdin/client/teams/TeamsApi.java
@@ -20,6 +20,9 @@ import com.crowdin.client.teams.model.TeamMember;
 import com.crowdin.client.teams.model.TeamMemberResponseList;
 import com.crowdin.client.teams.model.TeamResponseList;
 import com.crowdin.client.teams.model.TeamResponseObject;
+import com.crowdin.client.teams.model.GroupTeam;
+import com.crowdin.client.teams.model.GroupTeamResponseList;
+import com.crowdin.client.teams.model.GroupTeamResponseObject;
 
 import java.util.List;
 import java.util.Map;
@@ -32,6 +35,51 @@ public class TeamsApi extends CrowdinApi {
 
     public TeamsApi(Credentials credentials, ClientConfig clientConfig) {
         super(credentials, clientConfig);
+    }
+
+    /**
+     * List group teams. For Crowdin Enterprise only
+     * @param groupId group identifier
+     * @param orderBy
+     * @return list of group teams
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.groups.teams.getMany" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseList<GroupTeam> listGroupTeams(Long groupId, String orderBy) throws HttpException, HttpBadRequestException {
+        Map<String, Optional<Object>> queryParams = HttpRequestConfig.buildUrlParams(
+                "orderBy", Optional.ofNullable(orderBy)
+        );
+        GroupTeamResponseList response = this.httpClient.get(this.url + "/groups/" + groupId + "/teams", new HttpRequestConfig(queryParams), GroupTeamResponseList.class);
+        return GroupTeamResponseList.to(response);
+    }
+
+    /**
+     * Update group teams. For Crowdin Enterprise only
+     * @param groupId group identifier
+     * @param request request object
+     * @return list of updated group teams
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.groups.teams.patch" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseList<GroupTeam> updateGroupTeams(Long groupId, List<PatchRequest> request) throws HttpException, HttpBadRequestException {
+        GroupTeamResponseList response = this.httpClient.patch(this.url + "/groups/" + groupId + "/teams", request, new HttpRequestConfig(), GroupTeamResponseList.class);
+        return GroupTeamResponseList.to(response);
+    }
+
+    /**
+     * Get group team. For Crowdin Enterprise only
+     * @param groupId group identifier
+     * @param teamId team identifier
+     * @return group team
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.groups.teams.get" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseObject<GroupTeam> getGroupTeam(Long groupId, Long teamId) throws HttpException, HttpBadRequestException {
+        GroupTeamResponseObject response = this.httpClient.get(this.url + "/groups/" + groupId + "/teams/" + teamId, new HttpRequestConfig(), GroupTeamResponseObject.class);
+        return ResponseObject.of(response.getData());
     }
 
     /**

--- a/src/main/java/com/crowdin/client/teams/model/GroupTeam.java
+++ b/src/main/java/com/crowdin/client/teams/model/GroupTeam.java
@@ -1,0 +1,10 @@
+package com.crowdin.client.teams.model;
+
+import lombok.Data;
+
+@Data
+public class GroupTeam {
+
+    private Long id;
+    private Team team;
+}

--- a/src/main/java/com/crowdin/client/teams/model/GroupTeamResponseList.java
+++ b/src/main/java/com/crowdin/client/teams/model/GroupTeamResponseList.java
@@ -1,0 +1,26 @@
+package com.crowdin.client.teams.model;
+
+import com.crowdin.client.core.model.Pagination;
+import com.crowdin.client.core.model.ResponseList;
+import com.crowdin.client.core.model.ResponseObject;
+import lombok.Data;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+public class GroupTeamResponseList {
+
+    private List<GroupTeamResponseObject> data;
+    private Pagination pagination;
+
+    public static ResponseList<GroupTeam> to(GroupTeamResponseList groupTeamResponseList) {
+        return ResponseList.of(
+                groupTeamResponseList.getData().stream()
+                        .map(GroupTeamResponseObject::getData)
+                        .map(ResponseObject::of)
+                        .collect(Collectors.toList()),
+                groupTeamResponseList.getPagination()
+        );
+    }
+}

--- a/src/main/java/com/crowdin/client/teams/model/GroupTeamResponseObject.java
+++ b/src/main/java/com/crowdin/client/teams/model/GroupTeamResponseObject.java
@@ -1,0 +1,9 @@
+package com.crowdin.client.teams.model;
+
+import lombok.Data;
+
+@Data
+public class GroupTeamResponseObject {
+
+    private GroupTeam data;
+}

--- a/src/main/java/com/crowdin/client/users/UsersApi.java
+++ b/src/main/java/com/crowdin/client/users/UsersApi.java
@@ -22,6 +22,53 @@ public class UsersApi extends CrowdinApi {
     }
 
     /**
+     * List group managers. For Crowdin Enterprise only
+     * @param groupId Group Identifier. Get via List Groups
+     * @param teamIds Defines team ids. It can be one team id or a list of comma-separated ones.
+     * @param orderBy
+     * @return list of group managers
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.groups.managers.getMany" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseList<GroupManager> listGroupManagers(Long groupId, List<Long> teamIds, String orderBy) throws HttpException, HttpBadRequestException {
+        Map<String, Optional<Object>> queryParams = HttpRequestConfig.buildUrlParams(
+                "teamIds", Optional.ofNullable(teamIds),
+                "orderBy", Optional.ofNullable(orderBy)
+        );
+        GroupManagerResponseList response = this.httpClient.get(this.url + "/groups/" + groupId + "/managers", new HttpRequestConfig(queryParams), GroupManagerResponseList.class);
+        return GroupManagerResponseList.to(response);
+    }
+
+    /**
+     * Update group managers. For Crowdin Enterprise only
+     * @param groupId group identifier
+     * @param request request object
+     * @return list of updated group managers
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.groups.managers.patch" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseList<GroupManager> updateGroupManagers(Long groupId, List<PatchRequest> request) throws HttpException, HttpBadRequestException {
+        GroupManagerResponseList response = this.httpClient.patch(this.url + "/groups/" + groupId + "/managers", request, new HttpRequestConfig(), GroupManagerResponseList.class);
+        return GroupManagerResponseList.to(response);
+    }
+
+    /**
+     * Get group manager. For Crowdin Enterprise only
+     * @param groupId group identifier
+     * @param userId user identifier
+     * @return group manager
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.groups.managers.get" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseObject<GroupManager> getGroupManager(Long groupId, Long userId) throws HttpException, HttpBadRequestException {
+        GroupManagerResponseObject response = this.httpClient.get(this.url + "/groups/" + groupId + "/managers/" + userId, new HttpRequestConfig(), GroupManagerResponseObject.class);
+        return ResponseObject.of(response.getData());
+    }
+
+    /**
      * List project members. For Crowdin Enterprise only
      * @param projectId Project Identifier. Get via List Projects
      * @param search Search users by firstName, lastName or username

--- a/src/main/java/com/crowdin/client/users/model/GroupManager.java
+++ b/src/main/java/com/crowdin/client/users/model/GroupManager.java
@@ -1,0 +1,13 @@
+package com.crowdin.client.users.model;
+
+import com.crowdin.client.teams.model.GroupTeam;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class GroupManager {
+    private Long id;
+    private User user;
+    private List<GroupTeam> teams;
+}

--- a/src/main/java/com/crowdin/client/users/model/GroupManagerResponseList.java
+++ b/src/main/java/com/crowdin/client/users/model/GroupManagerResponseList.java
@@ -1,0 +1,25 @@
+package com.crowdin.client.users.model;
+
+import com.crowdin.client.core.model.Pagination;
+import com.crowdin.client.core.model.ResponseList;
+import com.crowdin.client.core.model.ResponseObject;
+import lombok.Data;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+public class GroupManagerResponseList {
+    private List<GroupManagerResponseObject> data;
+    private Pagination pagination;
+
+    public static ResponseList<GroupManager> to(GroupManagerResponseList groupManagerResponseList) {
+        return ResponseList.of(
+                groupManagerResponseList.getData().stream()
+                        .map(GroupManagerResponseObject::getData)
+                        .map(ResponseObject::of)
+                        .collect(Collectors.toList()),
+                groupManagerResponseList.getPagination()
+        );
+    }
+}

--- a/src/main/java/com/crowdin/client/users/model/GroupManagerResponseObject.java
+++ b/src/main/java/com/crowdin/client/users/model/GroupManagerResponseObject.java
@@ -1,0 +1,8 @@
+package com.crowdin.client.users.model;
+
+import lombok.Data;
+
+@Data
+public class GroupManagerResponseObject {
+    private GroupManager data;
+}

--- a/src/test/resources/api/teams/editGroupTeams.json
+++ b/src/test/resources/api/teams/editGroupTeams.json
@@ -1,0 +1,13 @@
+[
+  {
+    "op": "add",
+    "path": "/-",
+    "value": {
+      "teamId": 1
+    }
+  },
+  {
+    "op": "remove",
+    "path": "/24"
+  }
+]

--- a/src/test/resources/api/teams/groupTeam.json
+++ b/src/test/resources/api/teams/groupTeam.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "id": 27,
+    "team": {
+      "id": 1,
+      "name": "French",
+      "totalMembers": 8,
+      "createdAt": "2019-09-23T09:04:29+00:00",
+      "updatedAt": "2019-09-23T09:04:29+00:00"
+    }
+  }
+}

--- a/src/test/resources/api/teams/listGroupTeams.json
+++ b/src/test/resources/api/teams/listGroupTeams.json
@@ -1,0 +1,20 @@
+{
+  "data": [
+    {
+      "data": {
+        "id": 27,
+        "team": {
+          "id": 1,
+          "name": "French",
+          "totalMembers": 8,
+          "createdAt": "2019-09-23T09:04:29+00:00",
+          "updatedAt": "2019-09-23T09:04:29+00:00"
+        }
+      }
+    }
+  ],
+  "pagination": {
+    "offset": 0,
+    "limit": 25
+  }
+}

--- a/src/test/resources/api/users/editGroupManagers.json
+++ b/src/test/resources/api/users/editGroupManagers.json
@@ -1,0 +1,13 @@
+[
+  {
+    "op": "add",
+    "path": "/-",
+    "value": {
+      "userId": 1
+    }
+  },
+  {
+    "op": "remove",
+    "path": "/24"
+  }
+]

--- a/src/test/resources/api/users/groupManager.json
+++ b/src/test/resources/api/users/groupManager.json
@@ -1,0 +1,27 @@
+{
+  "data": {
+    "id": 27,
+    "user": {
+      "id": 1,
+      "username": "john_smith",
+      "firstName": "John",
+      "lastName": "Smith",
+      "status": "active",
+      "avatarUrl": "",
+      "createdAt": "2019-07-11T07:40:22+00:00",
+      "lastSeen": "2019-10-23T11:44:02+00:00",
+      "twoFactor": "enabled",
+      "isAdmin": true,
+      "timezone": "Europe/Kyiv"
+    },
+    "teams": [
+      {
+        "id": 2,
+        "name": "Translators Team",
+        "totalMembers": 8,
+        "createdAt": "2019-09-23T09:04:29+00:00",
+        "updatedAt": "2019-09-23T09:04:29+00:00"
+      }
+    ]
+  }
+}

--- a/src/test/resources/api/users/listGroupManagers.json
+++ b/src/test/resources/api/users/listGroupManagers.json
@@ -1,0 +1,35 @@
+{
+  "data": [
+    {
+      "data": {
+        "id": 27,
+        "user": {
+          "id": 1,
+          "username": "john_smith",
+          "firstName": "John",
+          "lastName": "Smith",
+          "status": "active",
+          "avatarUrl": "",
+          "createdAt": "2019-07-11T07:40:22+00:00",
+          "lastSeen": "2019-10-23T11:44:02+00:00",
+          "twoFactor": "enabled",
+          "isAdmin": true,
+          "timezone": "Europe/Kyiv"
+        },
+        "teams": [
+          {
+            "id": 2,
+            "name": "Translators Team",
+            "totalMembers": 8,
+            "createdAt": "2019-09-23T09:04:29+00:00",
+            "updatedAt": "2019-09-23T09:04:29+00:00"
+          }
+        ]
+      }
+    }
+  ],
+  "pagination": {
+    "offset": 0,
+    "limit": 25
+  }
+}


### PR DESCRIPTION
<details><summary>Summary</summary>
<p>
This introduces support for managing group managers and teams in the application.
</p>
</details> 

Targets: [issue#312](https://github.com/crowdin/crowdin-api-client-java/issues/312)

### Changes
- Added models for `GroupManager` and `GroupTeam`, including response handling models (`GroupManagerResponseList`, `GroupTeamResponseList`, `...`).
- Implemented endpoints to `list`, `update`, and `retrieve` group managers and teams.
- Added unit tests to verify the functionality of new endpoints.
- Included mock server data for API responses to ensure correctness.

### Testing
- Mock data was added to test the newly API use cases like `listing`, `retrieving`, and `updating` group teams and managers.
- All tests passed successfully.

### Additional notes
- New classes (e.g. `GroupTeam`) were created because the new API methods had response structures that differed from existing ones. For instance, the `List Group Teams` response includes a `unique identifier` and a nested `team` object, which matches the structure of the `List Teams` API.
- Existing models were reused in the newly models to avoid redundancy, but new classes were necessary to handle unique fields and correctly map the API responses as per the documentation.