### PR TITLE
feat: add support for file references api

### DIFF
--- a/src/main/java/com/crowdin/client/sourcefiles/SourceFilesApi.java
+++ b/src/main/java/com/crowdin/client/sourcefiles/SourceFilesApi.java
@@ -481,4 +481,67 @@ public class SourceFilesApi extends CrowdinApi {
         DownloadLinkResponseObject downloadLinkResponseObject = this.httpClient.get(this.url + "/projects/" + projectId + "/files/" + fileId + "/preview", new HttpRequestConfig(), DownloadLinkResponseObject.class);
         return ResponseObject.of(downloadLinkResponseObject.getData());
     }
+
+    /**
+     * @param projectId project identifier
+     * @param fileId file identifier
+     * @param limit maximum number of items to retrieve (default 25)
+     * @param offset starting offset in the collection (default 0)
+     * @return list of asset references
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.projects.files.references.getMany" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.files.references.getMany" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseList<AssetReference> listAssetReferences(Long projectId, Long fileId, Integer limit, Integer offset) throws HttpException, HttpBadRequestException {
+        Map<String, Optional<Object>> queryParams = HttpRequestConfig.buildUrlParams(
+                "limit", Optional.ofNullable(limit),
+                "offset", Optional.ofNullable(offset)
+        );
+        AssetReferenceResponseList assetReferenceResponseList = this.httpClient.get(this.url + "/projects/" + projectId + "/files/" + fileId + "/references", new HttpRequestConfig(queryParams), AssetReferenceResponseList.class);
+        return AssetReferenceResponseList.to(assetReferenceResponseList);
+    }
+
+    /**
+     * @param projectId project identifier
+     * @param fileId file identifier
+     * @param referenceId reference identifier
+     * @return asset reference
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.projects.files.references.get" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.files.references.get" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseObject<AssetReference> getAssetReference(Long projectId, Long fileId, Long referenceId) throws HttpException, HttpBadRequestException {
+        AssetReferenceResponseObject assetResponseObject = this.httpClient.get(this.url + "/projects/" + projectId + "/files/" + fileId + "/references/" + referenceId, new HttpRequestConfig(), AssetReferenceResponseObject.class);
+        return ResponseObject.of(assetResponseObject.getData());
+    }
+
+    /**
+     * @param projectId project identifier
+     * @param fileId file identifier
+     * @param request request object
+     * @return newly created asset reference
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.projects.files.references.post" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.files.references.post" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseObject<AssetReference> addAssetReference(Long projectId, Long fileId, AddAssetReferenceRequest request) throws HttpException, HttpBadRequestException {
+        AssetReferenceResponseObject post = this.httpClient.post(this.url + "/projects/" + projectId + "/files/" + fileId + "/references", request, new HttpRequestConfig(), AssetReferenceResponseObject.class);
+        return ResponseObject.of(post.getData());
+    }
+
+    /**
+     * @param projectId project identifier
+     * @param fileId file identifier
+     * @param referenceId reference identifier
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.projects.files.references.delete" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.files.references.delete" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public void deleteAssetReference(Long projectId, Long fileId, Long referenceId) throws HttpException, HttpBadRequestException {
+        this.httpClient.delete(this.url + "/projects/" + projectId + "/files/" + fileId + "/references/" + referenceId, new HttpRequestConfig(), Void.class);
+    }
 }

--- a/src/main/java/com/crowdin/client/sourcefiles/model/AddAssetReferenceRequest.java
+++ b/src/main/java/com/crowdin/client/sourcefiles/model/AddAssetReferenceRequest.java
@@ -1,0 +1,9 @@
+package com.crowdin.client.sourcefiles.model;
+
+import lombok.Data;
+
+@Data
+public class AddAssetReferenceRequest {
+    private Long storageId;
+    private String name;
+}

--- a/src/main/java/com/crowdin/client/sourcefiles/model/AssetReference.java
+++ b/src/main/java/com/crowdin/client/sourcefiles/model/AssetReference.java
@@ -1,0 +1,23 @@
+package com.crowdin.client.sourcefiles.model;
+
+import lombok.Data;
+
+import java.util.Date;
+
+@Data
+public class AssetReference {
+    private Long id;
+    private String name;
+    private String url;
+    private User user;
+    private Date createdAt;
+    private String mimeType;
+
+    @Data
+    public static class User {
+        private Long id;
+        private String username;
+        private String fullName;
+        private String avatarUrl;
+    }
+}

--- a/src/main/java/com/crowdin/client/sourcefiles/model/AssetReferenceResponseList.java
+++ b/src/main/java/com/crowdin/client/sourcefiles/model/AssetReferenceResponseList.java
@@ -1,0 +1,24 @@
+package com.crowdin.client.sourcefiles.model;
+
+import com.crowdin.client.core.model.Pagination;
+import com.crowdin.client.core.model.ResponseList;
+import com.crowdin.client.core.model.ResponseObject;
+import lombok.Data;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+public class AssetReferenceResponseList {
+    private List<AssetReferenceResponseObject> data;
+    private Pagination pagination;
+
+    public static ResponseList<AssetReference> to(AssetReferenceResponseList assetReferenceList) {
+        return ResponseList.of(assetReferenceList.getData().stream()
+                .map(AssetReferenceResponseObject::getData)
+                .map(ResponseObject::of)
+                .collect(Collectors.toList()),
+        assetReferenceList.getPagination()
+        );
+    }
+}

--- a/src/main/java/com/crowdin/client/sourcefiles/model/AssetReferenceResponseObject.java
+++ b/src/main/java/com/crowdin/client/sourcefiles/model/AssetReferenceResponseObject.java
@@ -1,0 +1,8 @@
+package com.crowdin.client.sourcefiles.model;
+
+import lombok.Data;
+
+@Data
+public class AssetReferenceResponseObject {
+    private AssetReference data;
+}

--- a/src/test/resources/api/sourcefiles/addAssetReferenceRequest.json
+++ b/src/test/resources/api/sourcefiles/addAssetReferenceRequest.json
@@ -1,0 +1,4 @@
+{
+  "storageId": 67890,
+  "name": "design_reference.png"
+}

--- a/src/test/resources/api/sourcefiles/assetReference.json
+++ b/src/test/resources/api/sourcefiles/assetReference.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "id": 123,
+    "name": "design_reference.png",
+    "url": "https://example.com/reference/design_reference.png",
+    "user": {
+      "id": 1,
+      "username": "john_doe",
+      "fullName": "John Smith",
+      "avatarUrl": ""
+    },
+    "createdAt": "2019-09-20T11:05:24+00:00",
+    "mimeType": "image/png"
+  }
+}

--- a/src/test/resources/api/sourcefiles/listAssetReferences.json
+++ b/src/test/resources/api/sourcefiles/listAssetReferences.json
@@ -1,0 +1,23 @@
+{
+  "data": [
+    {
+      "data": {
+        "id": 123,
+        "name": "design_reference.png",
+        "url": "https://example.com/reference/design_reference.png",
+        "user": {
+          "id": 1,
+          "username": "john_doe",
+          "fullName": "John Smith",
+          "avatarUrl": ""
+        },
+        "createdAt": "2019-09-20T11:05:24+00:00",
+        "mimeType": "image/png"
+      }
+    }
+  ],
+  "pagination": {
+    "offset": 0,
+    "limit": 25
+  }
+}


### PR DESCRIPTION
Introduces support for File References API (closes: #341)

**Changes:**
* New endpoints to manage the File References API, as per documentation: two `GET`, one `POST`, and one `DELETE`;
* Added `AssetReference.class` (model), `AssetReferenceResponseObject.class` (mapping as a `ResponseObject`), `AssetReferenceResponseList.class` (mapping as a `ResponseList`), and `AddAssetReferenceRequest.class` (represents the body request required for `POST`);
* An inner class `User.class` inside `AssetReference.class` that models the user;
* All methods implemented are unit-tested, with all tests passing.

**Notes:**
* I named classes with `AssetReference` prefix, but if it was more suitable to use just `Reference` I can refactor that to match the requirements;
* Any feedback regarding the implementation or further adjustments that need to be made would be much appreciated.