### PR TITLE
feat: add support for string comments attachments

### DIFF
--- a/src/main/java/com/crowdin/client/stringcomments/StringCommentsApi.java
+++ b/src/main/java/com/crowdin/client/stringcomments/StringCommentsApi.java
@@ -2,6 +2,8 @@ package com.crowdin.client.stringcomments;
 
 import com.crowdin.client.core.CrowdinApi;
 import com.crowdin.client.core.http.HttpRequestConfig;
+import com.crowdin.client.core.http.exceptions.HttpBadRequestException;
+import com.crowdin.client.core.http.exceptions.HttpException;
 import com.crowdin.client.core.model.*;
 import com.crowdin.client.stringcomments.model.AddStringCommentRequest;
 import com.crowdin.client.stringcomments.model.IssueStatus;
@@ -146,13 +148,27 @@ public class StringCommentsApi extends CrowdinApi {
      * @param request request object
      * @return list of updated string comment objects
      * @see <ul>
-     * <li><a href="https://support.crowdin.com/developer/api/v2/#tag/String-Comments/operation/api.projects.comments.batchPatch" target="_blank"><b>API Documentation</b></a></li>
-     * <li><a href="https://support.crowdin.com/developer/enterprise/api/v2/#tag/String-Comments/operation/api.projects.comments.batchPatch" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * <li><a href="https://support.crowdin.com/developer/api/v2/#operation/api.projects.comments.batchPatch" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://support.crowdin.com/developer/enterprise/api/v2/#operation/api.projects.comments.batchPatch" target="_blank"><b>Enterprise API Documentation</b></a></li>
      * </ul>
      */
     public ResponseList<StringComment> stringCommentBatchOperations(Long projectId, List<PatchRequest> request) {
         String builtUrl = String.format("%s/projects/%d/comments", this.url, projectId);
         StringCommentResponseList response = this.httpClient.patch(builtUrl, request, new HttpRequestConfig(), StringCommentResponseList.class);
         return StringCommentResponseList.to(response);
+    }
+
+    /**
+     * @param projectId project identifier
+     * @param commentId comment identifier
+     * @param attachmentId attachment identifier
+     * @see <ul>
+     * <li><a href="https://support.crowdin.com/developer/api/v2/#operation/api.projects.comments.attachments.delete" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://support.crowdin.com/developer/enterprise/api/v2/#operation/api.projects.comments.attachments.delete" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public void deleteAttachmentFromStringComment(Long projectId, Long commentId, Long attachmentId) throws HttpException, HttpBadRequestException {
+        String builtUrl = String.format("%s/projects/%d/comments/%d/attachments/%d", this.url, projectId, commentId, attachmentId);
+        this.httpClient.delete(builtUrl, new HttpRequestConfig(), Void.class);
     }
 }

--- a/src/main/java/com/crowdin/client/stringcomments/model/AddStringCommentRequest.java
+++ b/src/main/java/com/crowdin/client/stringcomments/model/AddStringCommentRequest.java
@@ -2,6 +2,8 @@ package com.crowdin.client.stringcomments.model;
 
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 public class AddStringCommentRequest {
 
@@ -11,4 +13,5 @@ public class AddStringCommentRequest {
     private Type type;
     private String issueType;
     private IssueStatus issueStatus;
+    private List<Attachment> attachments;
 }

--- a/src/main/java/com/crowdin/client/stringcomments/model/Attachment.java
+++ b/src/main/java/com/crowdin/client/stringcomments/model/Attachment.java
@@ -1,0 +1,15 @@
+package com.crowdin.client.stringcomments.model;
+
+import lombok.Data;
+
+@Data
+public class Attachment {
+    private Long id;
+    private String name;
+    private String mime;
+    private Long size;
+    private String category;
+    private String thumbnailUrl;
+    private String url;
+    private String downloadUrl;
+}

--- a/src/main/java/com/crowdin/client/stringcomments/model/StringComment.java
+++ b/src/main/java/com/crowdin/client/stringcomments/model/StringComment.java
@@ -3,6 +3,7 @@ package com.crowdin.client.stringcomments.model;
 import lombok.Data;
 
 import java.util.Date;
+import java.util.List;
 
 @Data
 public class StringComment {
@@ -18,6 +19,7 @@ public class StringComment {
     private String issueType;
     private IssueStatus issueStatus;
     private Date createdAt;
+    private List<Attachment> attachments;
 
     @Data
     public static class User {

--- a/src/test/java/com/crowdin/client/stringcomments/StringCommentsApiTest.java
+++ b/src/test/java/com/crowdin/client/stringcomments/StringCommentsApiTest.java
@@ -4,6 +4,7 @@ import com.crowdin.client.core.model.*;
 import com.crowdin.client.framework.RequestMock;
 import com.crowdin.client.framework.TestClient;
 import com.crowdin.client.stringcomments.model.AddStringCommentRequest;
+import com.crowdin.client.stringcomments.model.Attachment;
 import com.crowdin.client.stringcomments.model.IssueStatus;
 import com.crowdin.client.stringcomments.model.StringComment;
 import com.crowdin.client.stringcomments.model.Type;
@@ -23,10 +24,12 @@ public class StringCommentsApiTest extends TestClient {
     private final Long projectId = 8L;
     private final Long project2Id = 9L;
     private final Long project3Id = 10L;
-    private final Long stringId = 64L;
+    private final Long stringId = 1L;
     private final Long stringCommentId = 512L;
+    private final Long attachmentId = 123L;
+    private final Long attachmentId2 = 10L;
 
-    private final String text = "some issue";
+    private final String text = "some issue with translation";
     private final String targetLanguageId = "en";
     private final Type type = Type.ISSUE;
     private final String issueType = "translation_mistake";
@@ -58,7 +61,8 @@ public class StringCommentsApiTest extends TestClient {
                     HttpPatch.METHOD_NAME,
                     "api/stringcomments/stringCommentBatchOperationsRequest.json",
                     "api/stringcomments/stringCommentBatchOperationsResponse.json"
-            )
+            ),
+            RequestMock.build(String.format("%s/projects/%d/comments/%d/attachments/%d", this.url, projectId, stringCommentId, attachmentId), HttpDelete.METHOD_NAME)
         );
     }
 
@@ -68,6 +72,7 @@ public class StringCommentsApiTest extends TestClient {
         assertNotNull(responseList);
         assertNotNull(responseList.getData());
         assertEquals(1, responseList.getData().size(), "Size of list should be 1");
+        assertEquals(attachmentId2, responseList.getData().get(0).getData().getAttachments().get(0).getId());
     }
 
     @Test
@@ -85,6 +90,7 @@ public class StringCommentsApiTest extends TestClient {
         assertNotNull(responseList);
         assertNotNull(responseList.getData());
         assertEquals(1, responseList.getData().size(), "Size of list should be 1");
+        assertEquals(attachmentId2, responseList.getData().get(0).getData().getAttachments().get(0).getId());
     }
 
     @Test
@@ -108,6 +114,7 @@ public class StringCommentsApiTest extends TestClient {
 
         assertEquals(2, responseList.getData().get(0).getData().getId(), "Id of list should be 2");
         assertEquals(3, responseList.getData().get(1).getData().getId(), "Id of list should be 3");
+        assertEquals(attachmentId2, responseList.getData().get(0).getData().getAttachments().get(0).getId());
     }
 
     @Test
@@ -132,6 +139,7 @@ public class StringCommentsApiTest extends TestClient {
 
         assertEquals(2, responseList.getData().get(0).getData().getId(), "Id of list should be 2");
         assertEquals(3, responseList.getData().get(1).getData().getId(), "Id of list should be 3");
+        assertEquals(attachmentId2, responseList.getData().get(0).getData().getAttachments().get(0).getId());
     }
 
     @Test
@@ -156,21 +164,28 @@ public class StringCommentsApiTest extends TestClient {
 
         assertEquals(3, responseList.getData().get(0).getData().getId(), "Id of list should be 3");
         assertEquals(2, responseList.getData().get(1).getData().getId(), "Id of list should be 2");
+        assertEquals(attachmentId2, responseList.getData().get(0).getData().getAttachments().get(0).getId());
     }
 
     @Test
     public void addStringCommentTest() {
+        Attachment attachment = new Attachment();
+        attachment.setId(attachmentId);
+        List<Attachment> attachments = Collections.singletonList(attachment);
+
         AddStringCommentRequest request = new AddStringCommentRequest() {{
             setText(text);
             setTargetLanguageId(targetLanguageId);
             setStringId(stringId);
             setType(type);
             setIssueType(issueType);
-            setIssueStatus(issueStatus);
+            setAttachments(attachments);
         }};
         ResponseObject<StringComment> response = this.getStringCommentsApi().addStringComment(projectId, request);
         assertNotNull(response);
         assertNotNull(response.getData());
+
+        assertEquals(attachmentId2, response.getData().getAttachments().get(0).getId());
     }
 
     @Test
@@ -178,6 +193,8 @@ public class StringCommentsApiTest extends TestClient {
         ResponseObject<StringComment> response = this.getStringCommentsApi().getStringComment(projectId, stringCommentId);
         assertNotNull(response);
         assertNotNull(response.getData());
+
+        assertEquals(attachmentId2, response.getData().getAttachments().get(0).getId());
     }
 
     @Test
@@ -197,6 +214,7 @@ public class StringCommentsApiTest extends TestClient {
         assertNotNull(response);
         assertNotNull(response.getData());
 
+        assertEquals(attachmentId2, response.getData().getAttachments().get(0).getId());
     }
 
     @Test
@@ -234,5 +252,11 @@ public class StringCommentsApiTest extends TestClient {
         assertNotNull(response.getData());
 
         assertEquals(IssueStatus.UNRESOLVED, response.getData().get(0).getData().getIssueStatus());
+        assertEquals(attachmentId2, response.getData().get(0).getData().getAttachments().get(0).getId());
+    }
+
+    @Test
+    public void deleteAttachmentFromStringCommentTest() {
+        this.getStringCommentsApi().deleteAttachmentFromStringComment(projectId, stringCommentId, attachmentId);
     }
 }

--- a/src/test/resources/api/stringcomments/addStringCommentRequest.json
+++ b/src/test/resources/api/stringcomments/addStringCommentRequest.json
@@ -1,8 +1,12 @@
 {
-  "text": "some issue",
+  "stringId": 1,
+  "text": "some issue with translation",
   "targetLanguageId": "en",
-  "stringId": 64,
   "type": "issue",
   "issueType": "translation_mistake",
-  "issueStatus": "resolved"
+  "attachments": [
+    {
+      "id": 123
+    }
+  ]
 }

--- a/src/test/resources/api/stringcomments/listStringCommentsResponse.json
+++ b/src/test/resources/api/stringcomments/listStringCommentsResponse.json
@@ -25,7 +25,19 @@
         "type": "issue",
         "issueType": "source_mistake",
         "issueStatus": "unresolved",
-        "createdAt": "2019-09-20T11:05:24+00:00"
+        "createdAt": "2019-09-20T11:05:24+00:00",
+        "attachments": [
+          {
+            "id": 10,
+            "name": "screenshot.png",
+            "mime": "image/png",
+            "size": 12345,
+            "category": "image",
+            "thumbnailUrl": "https://example.com/thumbnail.png",
+            "url": "https://example.com/original.png",
+            "downloadUrl": "https://example.com/raw.png"
+          }
+        ]
       }
     }
   ],

--- a/src/test/resources/api/stringcomments/listStringCommentsResponseOrderByIdAsc.json
+++ b/src/test/resources/api/stringcomments/listStringCommentsResponseOrderByIdAsc.json
@@ -25,7 +25,19 @@
         "type": "issue",
         "issueType": "source_mistake",
         "issueStatus": "unresolved",
-        "createdAt": "2019-09-20T11:05:24+00:00"
+        "createdAt": "2019-09-20T11:05:24+00:00",
+        "attachments": [
+          {
+            "id": 10,
+            "name": "screenshot.png",
+            "mime": "image/png",
+            "size": 12345,
+            "category": "image",
+            "thumbnailUrl": "https://example.com/thumbnail.png",
+            "url": "https://example.com/original.png",
+            "downloadUrl": "https://example.com/raw.png"
+          }
+        ]
       }
     },
     {
@@ -53,7 +65,19 @@
         "type": "issue",
         "issueType": "source_mistake",
         "issueStatus": "unresolved",
-        "createdAt": "2019-09-20T11:05:24+00:00"
+        "createdAt": "2019-09-20T11:05:24+00:00",
+        "attachments": [
+          {
+            "id": 10,
+            "name": "screenshot.png",
+            "mime": "image/png",
+            "size": 12345,
+            "category": "image",
+            "thumbnailUrl": "https://example.com/thumbnail.png",
+            "url": "https://example.com/original.png",
+            "downloadUrl": "https://example.com/raw.png"
+          }
+        ]
       }
     }
   ],

--- a/src/test/resources/api/stringcomments/listStringCommentsResponseOrderByIdDesc.json
+++ b/src/test/resources/api/stringcomments/listStringCommentsResponseOrderByIdDesc.json
@@ -25,7 +25,19 @@
         "type": "issue",
         "issueType": "source_mistake",
         "issueStatus": "unresolved",
-        "createdAt": "2019-09-20T11:05:24+00:00"
+        "createdAt": "2019-09-20T11:05:24+00:00",
+        "attachments": [
+          {
+            "id": 10,
+            "name": "screenshot.png",
+            "mime": "image/png",
+            "size": 12345,
+            "category": "image",
+            "thumbnailUrl": "https://example.com/thumbnail.png",
+            "url": "https://example.com/original.png",
+            "downloadUrl": "https://example.com/raw.png"
+          }
+        ]
       }
     },
     {
@@ -53,7 +65,19 @@
         "type": "issue",
         "issueType": "source_mistake",
         "issueStatus": "unresolved",
-        "createdAt": "2019-09-20T11:05:24+00:00"
+        "createdAt": "2019-09-20T11:05:24+00:00",
+        "attachments": [
+          {
+            "id": 10,
+            "name": "screenshot.png",
+            "mime": "image/png",
+            "size": 12345,
+            "category": "image",
+            "thumbnailUrl": "https://example.com/thumbnail.png",
+            "url": "https://example.com/original.png",
+            "downloadUrl": "https://example.com/raw.png"
+          }
+        ]
       }
     }
   ],

--- a/src/test/resources/api/stringcomments/stringCommentBatchOperationsResponse.json
+++ b/src/test/resources/api/stringcomments/stringCommentBatchOperationsResponse.json
@@ -34,7 +34,19 @@
           "avatarUrl": ""
         },
         "resolvedAt": "2019-09-20T11:05:24+00:00",
-        "createdAt": "2019-09-20T11:05:24+00:00"
+        "createdAt": "2019-09-20T11:05:24+00:00",
+        "attachments": [
+          {
+            "id": 10,
+            "name": "screenshot.png",
+            "mime": "image/png",
+            "size": 12345,
+            "category": "image",
+            "thumbnailUrl": "https://example.com/thumbnail.png",
+            "url": "https://example.com/original.png",
+            "downloadUrl": "https://example.com/raw.png"
+          }
+        ]
       }
     }
   ]

--- a/src/test/resources/api/stringcomments/stringCommentResponse.json
+++ b/src/test/resources/api/stringcomments/stringCommentResponse.json
@@ -23,6 +23,18 @@
     "type": "issue",
     "issueType": "source_mistake",
     "issueStatus": "unresolved",
-    "createdAt": "2019-09-20T11:05:24+00:00"
+    "createdAt": "2019-09-20T11:05:24+00:00",
+    "attachments": [
+      {
+        "id": 10,
+        "name": "screenshot.png",
+        "mime": "image/png",
+        "size": 12345,
+        "category": "image",
+        "thumbnailUrl": "https://example.com/thumbnail.png",
+        "url": "https://example.com/original.png",
+        "downloadUrl": "https://example.com/raw.png"
+      }
+    ]
   }
 }


### PR DESCRIPTION
This adds support for **String/Asset Comments API**. (closes: #347)

**Changes:**
* Created an additional class: `Attachment.class` to model the attachment;
* `StringComment.class` and `AddStringCommentRequest.class` classes have been modified to contain a list of attachments;
* Implemented the method to delete an attachment from a string comment;
* Fixed a typo in the JavaDoc comment of the batch operations method (`PATCH`) to correctly redirect the user to the documentation;
* Response files (`JSON`) have been modified to take into account the new `attachments` field
* Added unit-testing coverage for added method, and for existing ones additional assertions to ensure correct functionality.

**Notes:**
* Any feedback regarding the implementation or if there is something that is not up to the requirements would be appreciated!