### PR TITLE
feat: add support for supported ai provider models

### DIFF
--- a/src/main/java/com/crowdin/client/ai/AIApi.java
+++ b/src/main/java/com/crowdin/client/ai/AIApi.java
@@ -561,6 +561,32 @@ public class AIApi extends CrowdinApi {
         return ResponseObject.of(response.getData());
     }
 
+    /**
+     * @param userId user identifier
+     * @param limit maximum numbers of items to retrieve (default 25)
+     * @param offset starting offset in the collection (default 0)
+     * @param providerType provider (e.g. open_ai)
+     * @param enabled filter by enabled providers
+     * @param orderBy
+     * @return List of supported AI models for a specific AI provider
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#tag/AI/operation/api.ai.providers.supported-models.crowdin.getMany" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#tag/AI/operation/api.ai.providers.supported-models.enterprise.getMany" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseList<AiSupportedModel> listSupportedAiProviderModels(Long userId, Integer limit, Integer offset, String providerType, Boolean enabled, String orderBy) throws HttpException, HttpBadRequestException {
+        Map<String, Optional<Object>> queryParams = HttpRequestConfig.buildUrlParams(
+                "limit", Optional.ofNullable(limit),
+                "offset", Optional.ofNullable(offset),
+                "providerType", Optional.ofNullable(providerType),
+                "enabled", Optional.ofNullable(enabled),
+                "orderBy", Optional.ofNullable(orderBy)
+        );
+        String url = getAIPath(userId, "ai/providers/supported-models");
+        AiSupportedModelResponseList responseList = this.httpClient.get(url, new HttpRequestConfig(queryParams), AiSupportedModelResponseList.class);
+        return AiSupportedModelResponseList.to(responseList);
+    }
+
     private String getAIPath(Long userId, String path) {
         return userId != null ? String.format("%s/users/%d/%s", this.url, userId, path) : String.format("%s/%s", this.url, path);
     }

--- a/src/main/java/com/crowdin/client/ai/model/AiSupportedModel.java
+++ b/src/main/java/com/crowdin/client/ai/model/AiSupportedModel.java
@@ -1,0 +1,50 @@
+package com.crowdin.client.ai.model;
+
+import lombok.Data;
+
+import java.util.Date;
+
+@Data
+public class AiSupportedModel {
+    private Long providerId;
+    private String providerType;
+    private String providerName;
+    private String id;
+    private String displayName;
+    private Boolean supportReasoning;
+    private Integer intelligence;
+    private Integer speed;
+    private Price price;
+    private Modality modalities;
+    private Integer contextWindow;
+    private Integer maxOutputTokens;
+    private Date knowledgeCutoff;
+    private Date releaseDate;
+    private Feature features;
+
+    @Data
+    public static class Price {
+        private Double input;
+        private Double output;
+    }
+
+    @Data
+    public static class Modality {
+        private ModalityConfig input;
+        private ModalityConfig output;
+
+        @Data
+        public static class ModalityConfig {
+            private Boolean text;
+            private Boolean image;
+            private Boolean audio;
+        }
+    }
+
+    @Data
+    public static class Feature {
+        private Boolean streaming;
+        private Boolean structuredOutput;
+        private Boolean functionCalling;
+    }
+}

--- a/src/main/java/com/crowdin/client/ai/model/AiSupportedModelResponseList.java
+++ b/src/main/java/com/crowdin/client/ai/model/AiSupportedModelResponseList.java
@@ -1,0 +1,25 @@
+package com.crowdin.client.ai.model;
+
+import com.crowdin.client.core.model.Pagination;
+import com.crowdin.client.core.model.ResponseList;
+import com.crowdin.client.core.model.ResponseObject;
+import lombok.Data;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+public class AiSupportedModelResponseList {
+    private List<AiSupportedModelResponseObject> data;
+    private Pagination pagination;
+
+    public static ResponseList<AiSupportedModel> to(AiSupportedModelResponseList responseList) {
+        return ResponseList.of(
+                responseList.data.stream()
+                        .map(AiSupportedModelResponseObject::getData)
+                        .map(ResponseObject::of)
+                        .collect(Collectors.toList()),
+                responseList.getPagination()
+        );
+    }
+}

--- a/src/main/java/com/crowdin/client/ai/model/AiSupportedModelResponseObject.java
+++ b/src/main/java/com/crowdin/client/ai/model/AiSupportedModelResponseObject.java
@@ -1,0 +1,8 @@
+package com.crowdin.client.ai.model;
+
+import lombok.Data;
+
+@Data
+public class AiSupportedModelResponseObject {
+    private AiSupportedModel data;
+}

--- a/src/test/java/com/crowdin/client/ai/AIApiTest.java
+++ b/src/test/java/com/crowdin/client/ai/AIApiTest.java
@@ -25,6 +25,7 @@ public class AIApiTest extends TestClient {
     private static final long userId = 2L;
     private static final long customPlaceholderId = 2L;
     private static final long aiPromptId = 3L;
+    private static final long providerId = 0L;
     private static final long progress = 100L;
     private static final int year = 119;
     private static final int month = Calendar.SEPTEMBER;
@@ -64,6 +65,7 @@ public class AIApiTest extends TestClient {
     private static final String AI_PROMPT_COMPLETION = "%s/users/%d/ai/prompts/%d/completions/%s";
     private static final String AI_PROMPT_COMPLETION_DOWNLOAD = "%s/users/%d/ai/prompts/%d/completions/%s/download";
     private static final String PROXY_CHAT = "%s/users/%d/ai/providers/%d/chat/completions";
+    private static final String LIST_SUPPORTED_AI_PROVIDER_MODELS = "%s/users/%d/ai/providers/supported-models";
 
     @Override
     public List<RequestMock> getMocks() {
@@ -103,7 +105,8 @@ public class AIApiTest extends TestClient {
             RequestMock.build(String.format(AI_PROMPT, this.url, userId, aiPromptId), HttpGet.METHOD_NAME, "api/ai/promptResponse.json"),
             RequestMock.build(String.format(AI_PROMPT, this.url, userId, aiPromptId), HttpDelete.METHOD_NAME),
             RequestMock.build(String.format(AI_PROMPT, this.url, userId, aiPromptId), HttpPatch.METHOD_NAME, "api/ai/editPromptRequest.json", "api/ai/promptResponse.json"),
-            RequestMock.build(String.format(PROXY_CHAT, this.url, userId, aiPromptId), HttpPost.METHOD_NAME, "api/ai/proxyChatCompletionRequest.json", "api/ai/proxyChatCompletionResponse.json")
+            RequestMock.build(String.format(PROXY_CHAT, this.url, userId, aiPromptId), HttpPost.METHOD_NAME, "api/ai/proxyChatCompletionRequest.json", "api/ai/proxyChatCompletionResponse.json"),
+            RequestMock.build(String.format(LIST_SUPPORTED_AI_PROVIDER_MODELS, this.url, userId), HttpGet.METHOD_NAME, "api/ai/listSupportedAiProviderModels.json")
         );
     }
 
@@ -514,5 +517,18 @@ public class AIApiTest extends TestClient {
         ResponseObject<Map<String, Object>> proxyChatCompletion = this.getAiApi().createProxyChatCompletion(userId, aiPromptId, req);
 
         assertEquals(proxyChatCompletion.getData().size(), 0);
+    }
+
+    @Test
+    public void listSupportedAiProviderModelsTest() {
+        ResponseList<AiSupportedModel> response = this.getAiApi().listSupportedAiProviderModels(userId, null, null, null, null, null);
+
+        assertEquals(1, response.getData().size());
+        assertEquals(providerId, response.getData().get(0).getData().getProviderId());
+        assertTrue(response.getData().get(0).getData().getFeatures().getStreaming());
+        assertEquals(new Date(year, Calendar.AUGUST, 24, 14, 15, 22), response.getData().get(0).getData().getKnowledgeCutoff());
+        assertTrue(response.getData().get(0).getData().getModalities().getInput().getText());
+        assertTrue(response.getData().get(0).getData().getModalities().getOutput().getImage());
+        assertEquals(0.1, response.getData().get(0).getData().getPrice().getInput());
     }
 }

--- a/src/test/resources/api/ai/listSupportedAiProviderModels.json
+++ b/src/test/resources/api/ai/listSupportedAiProviderModels.json
@@ -1,0 +1,41 @@
+{
+  "data": [
+    {
+      "data": {
+        "providerId": 0,
+        "providerType": "string",
+        "providerName": "string",
+        "id": "string",
+        "displayName": "string",
+        "supportReasoning": true,
+        "intelligence": 0,
+        "speed": 0,
+        "price": {
+          "input": 0.1,
+          "output": 0.1
+        },
+        "modalities": {
+          "input": {
+            "text": true,
+            "image": true,
+            "audio": true
+          },
+          "output": {
+            "text": true,
+            "image": true,
+            "audio": true
+          }
+        },
+        "contextWindow": 0,
+        "maxOutputTokens": 0,
+        "knowledgeCutoff": "2019-08-24T14:15:22Z",
+        "releaseDate": "2019-08-24T14:15:22Z",
+        "features": {
+          "streaming": true,
+          "structuredOutput": true,
+          "functionCalling": true
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This adds support for AI API. (closes: #349)

**Changes:**
* Created additional classes: `AiSupportedModel.class` to model the new resource, `AiSupportedModelResponseObject.class` to as a `ResponseObject`, and `AiSupportedModelResponseList.class` to map as a `ResponseList`;
* Added support for the new `GET` endpoint (listing) per requirements;
* Added a new JSON response file that matches the body response you would get from calling the new endpoint (for testing purposes);
* Unit-tested the new method to ensure correct functionality.

**Notes:**
* For objects such as `price`, or `modalities` and so on, I implemented them as `public inner classes` for `AiSupportedModel.class`, with addition that the `ModalityConfig.class` has an inner class as well, which makes it a bit nested. I considered making them "external" as separate files not necessarily since this new resource is only used in the context of this new API endpoint;
* Any feedback regarding the implementation will be appreciated, or if any changes need to be made I will gladly work on them!