### PR TITLE
fix: typo in trainingOptions variable name

### DIFF
--- a/src/main/java/com/crowdin/client/ai/model/FineTuningJob.java
+++ b/src/main/java/com/crowdin/client/ai/model/FineTuningJob.java
@@ -20,7 +20,7 @@ public class FineTuningJob {
         private Boolean dryRun;
         private Long aiPromptId;
         private Hyperparameters hyperparameters;
-        private Options trainignOptions;
+        private Options trainingOptions;
         private Options validationOptions;
         private String baseModel;
         private String fineTunedModel;


### PR DESCRIPTION
**What this PR does / Why we need it:**
Fixes a typo in the field name inside `JobAttribute` class of `FineTuningJob.java`.
- Before: `private Options trainignOptions;`
- After:  `private Options trainingOptions;`
The word "training" was misspelled as "trainign" (i and n letters transposed — a common transposition typo).