### PR TITLE
chore(distributions): mark `exportMode` and `fileIds` as deprecated

### DIFF
--- a/src/main/java/com/crowdin/client/distributions/model/AddDistributionRequest.java
+++ b/src/main/java/com/crowdin/client/distributions/model/AddDistributionRequest.java
@@ -6,8 +6,14 @@ import java.util.List;
 
 @Data
 public class AddDistributionRequest {
+
+    @Deprecated
     private ExportMode exportMode;
+
     private String name;
+
+    @Deprecated
     private List<Long> fileIds;
+
     private List<Integer> bundleIds;
 }


### PR DESCRIPTION
This marks deprecated parameters in Add Distribution request according to Crowdin API docs. (closes #361)

Changes:
- Marked AddDistributionRequest.exportMode and .fileIds as @Deprecated

Notes:
- No functional changes.