### PR TITLE
feat: add updateOption parameter to string editing endpoints

### DIFF
--- a/src/main/java/com/crowdin/client/sourcestrings/SourceStringsApi.java
+++ b/src/main/java/com/crowdin/client/sourcestrings/SourceStringsApi.java
@@ -191,7 +191,7 @@ public class SourceStringsApi extends CrowdinApi {
     /**
      * @param projectId project identifier
      * @param request request object
-     * @return updated source string
+     * @return list of updated source strings
      * @see <ul>
      * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.projects.strings.batchPatch" target="_blank"><b>API Documentation</b></a></li>
      * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.strings.batchPatch" target="_blank"><b>Enterprise API Documentation</b></a></li>
@@ -205,7 +205,7 @@ public class SourceStringsApi extends CrowdinApi {
      * @param projectId project identifier
      * @param request request object
      * @param updateOption defines whether existing translations and approvals are kept when a string is updated (applied only when {@code text} or {@code identifier} is changed)
-     * @return updated source string
+     * @return list of updated source strings
      * @see <ul>
      * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.projects.strings.batchPatch" target="_blank"><b>API Documentation</b></a></li>
      * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.strings.batchPatch" target="_blank"><b>Enterprise API Documentation</b></a></li>

--- a/src/main/java/com/crowdin/client/sourcestrings/SourceStringsApi.java
+++ b/src/main/java/com/crowdin/client/sourcestrings/SourceStringsApi.java
@@ -5,6 +5,7 @@ import com.crowdin.client.core.http.HttpRequestConfig;
 import com.crowdin.client.core.http.exceptions.HttpBadRequestException;
 import com.crowdin.client.core.http.exceptions.HttpException;
 import com.crowdin.client.core.model.*;
+import com.crowdin.client.sourcefiles.model.UpdateOption;
 import com.crowdin.client.sourcestrings.model.*;
 
 import java.util.List;
@@ -165,7 +166,25 @@ public class SourceStringsApi extends CrowdinApi {
      * </ul>
      */
     public ResponseObject<SourceString> editSourceString(Long projectId, Long stringId, List<PatchRequest> request) throws HttpException, HttpBadRequestException {
-        SourceStringResponseObject sourceStringResponseObject = this.httpClient.patch(this.url + "/projects/" + projectId + "/strings/" + stringId, request, new HttpRequestConfig(), SourceStringResponseObject.class);
+        return editSourceString(projectId, stringId, request, null);
+    }
+
+    /**
+     * @param projectId project identifier
+     * @param stringId string identifier
+     * @param request request object
+     * @param updateOption defines whether existing translations and approvals are kept when the string is updated (applied only when {@code text} or {@code identifier} is changed)
+     * @return updated source string
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.projects.strings.patch" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.strings.patch" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseObject<SourceString> editSourceString(Long projectId, Long stringId, List<PatchRequest> request, UpdateOption updateOption) throws HttpException, HttpBadRequestException {
+        HttpRequestConfig config = new HttpRequestConfig(HttpRequestConfig.buildUrlParams(
+                "updateOption", Optional.ofNullable(updateOption)
+        ));
+        SourceStringResponseObject sourceStringResponseObject = this.httpClient.patch(this.url + "/projects/" + projectId + "/strings/" + stringId, request, config, SourceStringResponseObject.class);
         return ResponseObject.of(sourceStringResponseObject.getData());
     }
 
@@ -179,8 +198,25 @@ public class SourceStringsApi extends CrowdinApi {
      * </ul>
      */
     public ResponseList<SourceString> stringBatchOperations(Long projectId, List<PatchRequest> request) throws HttpException, HttpBadRequestException {
+        return stringBatchOperations(projectId, request, null);
+    }
+
+    /**
+     * @param projectId project identifier
+     * @param request request object
+     * @param updateOption defines whether existing translations and approvals are kept when a string is updated (applied only when {@code text} or {@code identifier} is changed)
+     * @return updated source string
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.projects.strings.batchPatch" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.strings.batchPatch" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseList<SourceString> stringBatchOperations(Long projectId, List<PatchRequest> request, UpdateOption updateOption) throws HttpException, HttpBadRequestException {
+        HttpRequestConfig config = new HttpRequestConfig(HttpRequestConfig.buildUrlParams(
+                "updateOption", Optional.ofNullable(updateOption)
+        ));
         String url = this.url + "/projects/" + projectId + "/strings";
-        SourceStringResponseList sourceStringResponseList = this.httpClient.patch(url, request, new HttpRequestConfig(), SourceStringResponseList.class);
+        SourceStringResponseList sourceStringResponseList = this.httpClient.patch(url, request, config, SourceStringResponseList.class);
         return SourceStringResponseList.to(sourceStringResponseList);
     }
 }

--- a/src/test/java/com/crowdin/client/sourcestrings/SourceStringsApiTest.java
+++ b/src/test/java/com/crowdin/client/sourcestrings/SourceStringsApiTest.java
@@ -56,7 +56,7 @@ public class SourceStringsApiTest extends TestClient {
                 RequestMock.build(this.url + "/projects/" + projectId + "/strings/" + id, HttpDelete.METHOD_NAME),
                 RequestMock.build(this.url + "/projects/" + projectId + "/strings/" + id, HttpPatch.METHOD_NAME, "api/strings/editString.json", "api/strings/string.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/strings", HttpPatch.METHOD_NAME, "api/strings/stringBatchOperationsRequest.json", "api/strings/listStrings.json"),
-                new RequestMock(this.url + "/projects/" + projectId + "/strings/" + id2, "api/strings/editString.json", "api/strings/string.json", HttpPatch.METHOD_NAME, singletonMap("updateOption", UpdateOption.KEEP_TRANSLATIONS_AND_APPROVALS), emptyMap()),
+                new RequestMock(this.url + "/projects/" + project2Id + "/strings/" + id, "api/strings/editString.json", "api/strings/string.json", HttpPatch.METHOD_NAME, singletonMap("updateOption", UpdateOption.KEEP_TRANSLATIONS_AND_APPROVALS), emptyMap()),
                 new RequestMock(this.url + "/projects/" + project2Id + "/strings", "api/strings/stringBatchOperationsRequest.json", "api/strings/listStrings.json", HttpPatch.METHOD_NAME, singletonMap("updateOption", UpdateOption.CLEAR_TRANSLATIONS_AND_APPROVALS), emptyMap())
         );
     }
@@ -337,7 +337,7 @@ public class SourceStringsApiTest extends TestClient {
         request.setValue(text);
         request.setPath("/text");
         ResponseObject<SourceString> sourceStringResponseObject = this.getSourceStringsApi()
-                .editSourceString(projectId, id2, singletonList(request), UpdateOption.KEEP_TRANSLATIONS_AND_APPROVALS);
+                .editSourceString(project2Id, id, singletonList(request), UpdateOption.KEEP_TRANSLATIONS_AND_APPROVALS);
         assertEquals(sourceStringResponseObject.getData().getId(), id);
         assertEquals(sourceStringResponseObject.getData().getText(), text);
     }

--- a/src/test/java/com/crowdin/client/sourcestrings/SourceStringsApiTest.java
+++ b/src/test/java/com/crowdin/client/sourcestrings/SourceStringsApiTest.java
@@ -14,7 +14,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -53,7 +55,9 @@ public class SourceStringsApiTest extends TestClient {
                 RequestMock.build(this.url + "/projects/" + projectId + "/strings/" + id, HttpGet.METHOD_NAME, "api/strings/string.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/strings/" + id, HttpDelete.METHOD_NAME),
                 RequestMock.build(this.url + "/projects/" + projectId + "/strings/" + id, HttpPatch.METHOD_NAME, "api/strings/editString.json", "api/strings/string.json"),
-                RequestMock.build(this.url + "/projects/" + projectId + "/strings", HttpPatch.METHOD_NAME, "api/strings/stringBatchOperationsRequest.json", "api/strings/listStrings.json")
+                RequestMock.build(this.url + "/projects/" + projectId + "/strings", HttpPatch.METHOD_NAME, "api/strings/stringBatchOperationsRequest.json", "api/strings/listStrings.json"),
+                new RequestMock(this.url + "/projects/" + projectId + "/strings/" + id2, "api/strings/editString.json", "api/strings/string.json", HttpPatch.METHOD_NAME, singletonMap("updateOption", UpdateOption.KEEP_TRANSLATIONS_AND_APPROVALS), emptyMap()),
+                new RequestMock(this.url + "/projects/" + project2Id + "/strings", "api/strings/stringBatchOperationsRequest.json", "api/strings/listStrings.json", HttpPatch.METHOD_NAME, singletonMap("updateOption", UpdateOption.CLEAR_TRANSLATIONS_AND_APPROVALS), emptyMap())
         );
     }
 
@@ -324,5 +328,55 @@ public class SourceStringsApiTest extends TestClient {
         assertEquals(2, item.getProjectId());
         assertEquals(48, item.getFileId());
         assertEquals(667, item.getBranchId());
+    }
+
+    @Test
+    public void editStringWithUpdateOptionTest() {
+        PatchRequest request = new PatchRequest();
+        request.setOp(PatchOperation.REPLACE);
+        request.setValue(text);
+        request.setPath("/text");
+        ResponseObject<SourceString> sourceStringResponseObject = this.getSourceStringsApi()
+                .editSourceString(projectId, id2, singletonList(request), UpdateOption.KEEP_TRANSLATIONS_AND_APPROVALS);
+        assertEquals(sourceStringResponseObject.getData().getId(), id);
+        assertEquals(sourceStringResponseObject.getData().getText(), text);
+    }
+
+    @Test
+    public void stringBatchOperationsWithUpdateOptionTest() {
+        List<PatchRequest> request = new ArrayList<PatchRequest>() {{
+            add(new PatchRequest() {{
+                setOp(PatchOperation.REPLACE);
+                setPath("/2814/isHidden");
+                setValue(true);
+            }});
+            add(new PatchRequest() {{
+                setOp(PatchOperation.REPLACE);
+                setPath("/2814/context");
+                setValue("some context");
+            }});
+            add(new PatchRequest() {{
+                setOp(PatchOperation.ADD);
+                setPath("/-");
+                setValue(new SourceStringForm() {{
+                    setText("new added string");
+                    setIdentifier("a.b.c");
+                    setContext("context for new string");
+                    setFileId(5L);
+                    setIsHidden(false);
+                }});
+            }});
+            add(new PatchRequest() {{
+                setOp(PatchOperation.REMOVE);
+                setPath("/2815");
+            }});
+        }};
+
+        ResponseList<SourceString> response = this.getSourceStringsApi()
+                .stringBatchOperations(project2Id, request, UpdateOption.CLEAR_TRANSLATIONS_AND_APPROVALS);
+
+        SourceString item = response.getData().get(0).getData();
+        assertNotNull(item);
+        assertEquals(2814, item.getId());
     }
 }


### PR DESCRIPTION
Adds support for the `updateOption` query parameter on the source string editing endpoints, as requested in #371:

- `editSourceString` — `PATCH /projects/{projectId}/strings/{stringId}`
- `stringBatchOperations` — `PATCH /projects/{projectId}/strings`

`updateOption` defines whether existing translations and approvals are kept when a string is updated, and is applied only when `text` or `identifier` is changed. Allowed values:

- `keep_translations_and_approvals` (default)
- `keep_translations`
- `clear_translations_and_approvals`

### Implementation notes

- Reuses the existing `com.crowdin.client.sourcefiles.model.UpdateOption` enum (already reused by `UploadStringsRequest`); it is serialized to the API value through the existing `EnumConverter` handling in `HttpClient#appendUrlParams`.
- **Backwards compatible:** the existing `editSourceString(Long, Long, List<PatchRequest>)` and `stringBatchOperations(Long, List<PatchRequest>)` signatures are kept and delegate to the new overloads with `updateOption = null`.

### Tests

- Added `editStringWithUpdateOptionTest` and `stringBatchOperationsWithUpdateOptionTest` in `SourceStringsApiTest`.
- `./gradlew test` passes (full suite green).

Closes #371
