### PR TITLE
feat: add styleGuideIds to AI Translation requests

### DIFF
--- a/src/main/java/com/crowdin/client/ai/model/AiFileTranslationAddRequest.java
+++ b/src/main/java/com/crowdin/client/ai/model/AiFileTranslationAddRequest.java
@@ -13,6 +13,7 @@ public class AiFileTranslationAddRequest {
     private Integer parserVersion;
     private List<Long> tmIds;
     private List<Long> glossaryIds;
+    private List<Long> styleGuideIds;
     private Long aiPromptId;
     private Long aiProviderId;
     private String aiModelId;

--- a/src/main/java/com/crowdin/client/ai/model/AiTranslateRequest.java
+++ b/src/main/java/com/crowdin/client/ai/model/AiTranslateRequest.java
@@ -11,6 +11,7 @@ public class AiTranslateRequest {
     private String targetLanguageId;
     private List<Long> tmIds;
     private List<Long> glossaryIds;
+    private List<Long> styleGuideIds;
     private Long aiPromptId;
     private Long aiProviderId;
     private String aiModelId;

--- a/src/test/java/com/crowdin/client/ai/AIApiTest.java
+++ b/src/test/java/com/crowdin/client/ai/AIApiTest.java
@@ -559,6 +559,7 @@ public class AIApiTest extends TestClient {
         request.setTargetLanguageId("uk");
         request.setTmIds(Collections.singletonList(123L));
         request.setGlossaryIds(Collections.singletonList(456L));
+        request.setStyleGuideIds(Collections.singletonList(321L));
         request.setAiPromptId(789L);
         request.setAiProviderId(12L);
         request.setAiModelId("gpt-4.1");
@@ -582,6 +583,7 @@ public class AIApiTest extends TestClient {
         request.setParserVersion(1);
         request.setTmIds(Collections.singletonList(123L));
         request.setGlossaryIds(Collections.singletonList(456L));
+        request.setStyleGuideIds(Collections.singletonList(321L));
         request.setAiPromptId(789L);
         request.setAiProviderId(12L);
         request.setAiModelId("gpt-4.1");

--- a/src/test/resources/api/ai/addAiFileTranslationRequest.json
+++ b/src/test/resources/api/ai/addAiFileTranslationRequest.json
@@ -10,6 +10,9 @@
   "glossaryIds": [
     456
   ],
+  "styleGuideIds": [
+    321
+  ],
   "aiPromptId": 789,
   "aiProviderId": 12,
   "aiModelId": "gpt-4.1",

--- a/src/test/resources/api/ai/aiTranslateRequest.json
+++ b/src/test/resources/api/ai/aiTranslateRequest.json
@@ -10,6 +10,9 @@
   "glossaryIds": [
     456
   ],
+  "styleGuideIds": [
+    321
+  ],
   "aiPromptId": 789,
   "aiProviderId": 12,
   "aiModelId": "gpt-4.1",


### PR DESCRIPTION
Adds support for the optional `styleGuideIds` field on the **Apply Pre-Translation** request (`POST /projects/{projectId}/pre-translations`), as requested in #372.

`styleGuideIds` is an array of Style Guide identifiers used during pre-translation. It is added to both request variants to keep them consistent:

- `ApplyPreTranslationRequest` (file-based)
- `ApplyPreTranslationStringsBasedRequest` (strings-based)

### Tests

- Updated `applyPreTranslationTest` and `applyPreTranslationStringsBasedTest` (and their request fixtures) to set and send `styleGuideIds`.
- `./gradlew test` passes.

Closes #372
