### PR TITLE
feat: add request body and export settings to Export Bundle

### DIFF
--- a/src/main/java/com/crowdin/client/bundles/BundlesApi.java
+++ b/src/main/java/com/crowdin/client/bundles/BundlesApi.java
@@ -6,6 +6,7 @@ import com.crowdin.client.bundles.model.BundleExport;
 import com.crowdin.client.bundles.model.BundleExportResponseObject;
 import com.crowdin.client.bundles.model.BundleResponseList;
 import com.crowdin.client.bundles.model.BundleResponseObject;
+import com.crowdin.client.bundles.model.ExportBundleRequest;
 import com.crowdin.client.core.CrowdinApi;
 import com.crowdin.client.core.http.HttpRequestConfig;
 import com.crowdin.client.core.http.exceptions.HttpBadRequestException;
@@ -170,8 +171,22 @@ public class BundlesApi extends CrowdinApi {
      * </ul>
      */
     public ResponseObject<BundleExport> exportBundle(Long projectId, Long bundleId) throws HttpException, HttpBadRequestException {
+        return exportBundle(projectId, bundleId, null);
+    }
+
+    /**
+     * @param projectId project identifier
+     * @param bundleId  bundle identifier
+     * @param request   export settings (target languages, skip/approval options); may be {@code null}
+     * @return freshly created bundle export object
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.projects.bundles.exports.post" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.bundles.exports.post" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseObject<BundleExport> exportBundle(Long projectId, Long bundleId, ExportBundleRequest request) throws HttpException, HttpBadRequestException {
         BundleExportResponseObject response = this.httpClient.post(this.url + "/projects/" + projectId + "/bundles/" + bundleId + "/exports",
-                null,
+                request,
                 new HttpRequestConfig(),
                 BundleExportResponseObject.class);
         return ResponseObject.of(response.getData());

--- a/src/main/java/com/crowdin/client/bundles/model/ExportBundleRequest.java
+++ b/src/main/java/com/crowdin/client/bundles/model/ExportBundleRequest.java
@@ -5,9 +5,8 @@ import lombok.Data;
 import java.util.List;
 
 @Data
-public class BundleAttributes {
+public class ExportBundleRequest {
 
-    private Integer bundleId;
     private List<String> targetLanguageIds;
     private Boolean skipUntranslatedStrings;
     private Boolean skipUntranslatedFiles;

--- a/src/test/java/com/crowdin/client/bundles/BundlesApiTest.java
+++ b/src/test/java/com/crowdin/client/bundles/BundlesApiTest.java
@@ -32,6 +32,7 @@ public class BundlesApiTest extends TestClient {
     private final Long projectId = 1L;
     private final Long projectId2 = 2L;
     private final Long bundleId = 14L;
+    private final Long bundleId2 = 15L;
     private final Long fileInfoCollectionResourceId = 44L;
     private final Long fileCollectionResourceId = 43L;
     private final Long branchCollectionResourceId = 44L;
@@ -58,7 +59,8 @@ public class BundlesApiTest extends TestClient {
                 RequestMock.build(this.url + "/projects/" + projectId2 + "/bundles/" + branchCollectionResourceId + "/branches", HttpGet.METHOD_NAME, "api/bundles/branchCollectionResource.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/bundles/" + bundleId + "/exports/" + exportId + "/download", HttpGet.METHOD_NAME, "api/bundles/downloadBundle.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/bundles/" + bundleId + "/exports", HttpPost.METHOD_NAME, "api/bundles/exportBundle.json"),
-                RequestMock.build(this.url + "/projects/" + projectId + "/bundles/" + bundleId + "/exports/" + exportId, HttpGet.METHOD_NAME, "api/bundles/exportBundle.json")
+                RequestMock.build(this.url + "/projects/" + projectId + "/bundles/" + bundleId + "/exports/" + exportId, HttpGet.METHOD_NAME, "api/bundles/exportBundle.json"),
+                RequestMock.build(this.url + "/projects/" + projectId + "/bundles/" + bundleId2 + "/exports", HttpPost.METHOD_NAME, "api/bundles/exportBundleRequest.json", "api/bundles/exportBundleWithSettings.json")
         );
     }
 
@@ -164,6 +166,29 @@ public class BundlesApiTest extends TestClient {
         ResponseObject<BundleExport> response = this.getBundlesApi().exportBundle(projectId, bundleId);
         assertEquals(exportId, response.getData().getIdentifier());
         assertEquals(2,response.getData().getAttributes().getBundleId());
+    }
+
+    @Test
+    public void exportBundleWithRequestTest() {
+        ExportBundleRequest request = new ExportBundleRequest();
+        request.setTargetLanguageIds(Arrays.asList("uk", "de"));
+        request.setSkipUntranslatedStrings(true);
+        request.setSkipUntranslatedFiles(false);
+        request.setExportApprovedOnly(false);
+        request.setExportWithMinApprovalsCount(2);
+        request.setExportStringsThatPassedWorkflow(true);
+
+        ResponseObject<BundleExport> response = this.getBundlesApi().exportBundle(projectId, bundleId2, request);
+        BundleExport export = response.getData();
+        assertEquals(exportId, export.getIdentifier());
+        assertEquals(2, export.getAttributes().getBundleId());
+        assertEquals(Arrays.asList("uk", "de"), export.getAttributes().getTargetLanguageIds());
+        assertTrue(export.getAttributes().getSkipUntranslatedStrings());
+        assertFalse(export.getAttributes().getExportApprovedOnly());
+        assertEquals(2, export.getAttributes().getExportWithMinApprovalsCount());
+        assertTrue(export.getAttributes().getExportStringsThatPassedWorkflow());
+        assertNull(export.getStartedAt());
+        assertNull(export.getFinishedAt());
     }
 
     @Test

--- a/src/test/resources/api/bundles/exportBundleRequest.json
+++ b/src/test/resources/api/bundles/exportBundleRequest.json
@@ -1,0 +1,11 @@
+{
+  "targetLanguageIds": [
+    "uk",
+    "de"
+  ],
+  "skipUntranslatedStrings": true,
+  "skipUntranslatedFiles": false,
+  "exportApprovedOnly": false,
+  "exportWithMinApprovalsCount": 2,
+  "exportStringsThatPassedWorkflow": true
+}

--- a/src/test/resources/api/bundles/exportBundleWithSettings.json
+++ b/src/test/resources/api/bundles/exportBundleWithSettings.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "identifier": "50fb3506-4127-4ba8-8296-f97dc7e3e0c3",
+    "status": "created",
+    "progress": 0,
+    "attributes": {
+      "bundleId": 2,
+      "targetLanguageIds": [
+        "uk",
+        "de"
+      ],
+      "skipUntranslatedStrings": true,
+      "skipUntranslatedFiles": false,
+      "exportApprovedOnly": false,
+      "exportWithMinApprovalsCount": 2,
+      "exportStringsThatPassedWorkflow": true
+    },
+    "createdAt": "2019-09-23T11:26:54+00:00",
+    "updatedAt": "2019-09-23T11:26:54+00:00",
+    "startedAt": null,
+    "finishedAt": null,
+    "eta": null
+  }
+}


### PR DESCRIPTION
Adds the request body to **Export Bundle** (`POST /projects/{projectId}/bundles/{bundleId}/exports`) and surfaces the export settings on the response, as requested in #377.

### Request

New `ExportBundleRequest` carrying the export settings (covers both Crowdin and Crowdin Enterprise):

- `targetLanguageIds`
- `skipUntranslatedStrings`
- `skipUntranslatedFiles`
- `exportApprovedOnly` (Crowdin)
- `exportWithMinApprovalsCount` (Enterprise)
- `exportStringsThatPassedWorkflow` (Enterprise)

`exportBundle` gets a new overload taking `ExportBundleRequest`; the existing no-body overload is kept and delegates to it (backwards compatible).

### Response

`BundleAttributes` now exposes the export settings echoed back by the API (also covers **Check Bundle Export Status**). `startedAt`/`finishedAt` remain nullable.

### Tests

- Added `exportBundleWithRequestTest` with request/response fixtures (the response uses null `startedAt`/`finishedAt` to cover the nullability).
- `./gradlew test` passes.

Closes #377
