### PR TITLE
feat: add multi-value term filters and exportType to Export Glossary

### DIFF
--- a/src/main/java/com/crowdin/client/glossaries/model/ExportGlossaryRequest.java
+++ b/src/main/java/com/crowdin/client/glossaries/model/ExportGlossaryRequest.java
@@ -9,4 +9,11 @@ public class ExportGlossaryRequest {
 
     private GlossariesFormat format;
     private List<String> exportFields;
+    private ExportType exportType;
+    private List<Status> statuses;
+    private List<PartOfSpeech> partsOfSpeech;
+    private List<Type> types;
+    private List<Gender> genders;
+    private List<Long> authorIds;
+    private List<String> languageIds;
 }

--- a/src/main/java/com/crowdin/client/glossaries/model/ExportType.java
+++ b/src/main/java/com/crowdin/client/glossaries/model/ExportType.java
@@ -1,0 +1,16 @@
+package com.crowdin.client.glossaries.model;
+
+import com.crowdin.client.core.model.EnumConverter;
+
+public enum ExportType implements EnumConverter<ExportType> {
+    CONCEPTS, TERMS;
+
+    public static ExportType from(String value) {
+        return ExportType.valueOf(value.toUpperCase());
+    }
+
+    @Override
+    public String to(ExportType v) {
+        return v.name().toLowerCase();
+    }
+}

--- a/src/test/java/com/crowdin/client/glossaries/GlossariesApiTest.java
+++ b/src/test/java/com/crowdin/client/glossaries/GlossariesApiTest.java
@@ -221,6 +221,13 @@ public class GlossariesApiTest extends TestClient {
         ExportGlossaryRequest request = new ExportGlossaryRequest();
         request.setFormat(GlossariesFormat.CSV);
         request.setExportFields(Arrays.asList("term", "description", "partOfSpeech"));
+        request.setExportType(ExportType.TERMS);
+        request.setStatuses(Arrays.asList(Status.PREFERRED, Status.ADMITTED));
+        request.setPartsOfSpeech(Arrays.asList(PartOfSpeech.NOUN, PartOfSpeech.VERB));
+        request.setTypes(singletonList(Type.FULL_FORM));
+        request.setGenders(singletonList(Gender.MASCULINE));
+        request.setAuthorIds(Arrays.asList(1L, 2L));
+        request.setLanguageIds(Arrays.asList("en", "uk"));
         ResponseObject<GlossaryExportStatus> glossaryExportStatusResponseObject = this.getGlossariesApi().exportGlossary(glossaryId, request);
         assertEquals(glossaryExportStatusResponseObject.getData().getIdentifier(), exportId);
     }

--- a/src/test/resources/api/glossaries/exportGlossary.json
+++ b/src/test/resources/api/glossaries/exportGlossary.json
@@ -4,5 +4,28 @@
     "term",
     "description",
     "partOfSpeech"
+  ],
+  "exportType": "terms",
+  "statuses": [
+    "preferred",
+    "admitted"
+  ],
+  "partsOfSpeech": [
+    "noun",
+    "verb"
+  ],
+  "types": [
+    "full form"
+  ],
+  "genders": [
+    "masculine"
+  ],
+  "authorIds": [
+    1,
+    2
+  ],
+  "languageIds": [
+    "en",
+    "uk"
   ]
 }


### PR DESCRIPTION
Adds the new **Export Glossary** (`POST /glossaries/{glossaryId}/exports`) request fields, as requested in #375, so consumers can filter the exported terms by multiple values and control the export type.

### New fields on `ExportGlossaryRequest`

- `exportType` — `concepts` (default) or `terms`, via a new `ExportType` enum.
- `statuses`, `partsOfSpeech`, `types`, `genders` — multi-value filters (reuse the existing `Status`, `PartOfSpeech`, `Type`, `Gender` enums).
- `authorIds` — filter by one or more author IDs.
- `languageIds` — filter terms by one or more language IDs.

Note: the deprecated singular counterparts (`status`, `partOfSpeech`, `type`, `gender`, `authorId`) were never exposed by this SDK, so there is nothing to deprecate here — only the current (plural) fields are added.

### Tests

- Extended `exportGlossaryTest` (and its request fixture) to set and send all the new fields.
- `./gradlew test` passes.

Closes #375
