### PR TITLE
feat: add scope and re-translation options to Apply Pre-Translation

### DIFF
--- a/src/main/java/com/crowdin/client/translations/model/ApplyPreTranslationRequest.java
+++ b/src/main/java/com/crowdin/client/translations/model/ApplyPreTranslationRequest.java
@@ -16,7 +16,15 @@ public class ApplyPreTranslationRequest {
     private AutoApproveOption autoApproveOption;
     private Boolean duplicateTranslations;
     private Boolean skipApprovedTranslations;
+    /**
+     * @deprecated use {@link #scope} instead; cannot be combined with {@code scope}.
+     */
+    @Deprecated
     private Boolean translateUntranslatedOnly;
+    private Scope scope;
+    private String translationModifiedBefore;
+    private ReplaceTranslationsOption replaceTranslationsOption;
+    private Boolean resetApprovalStatus;
     private Integer minimumMatchRatio;
     private Boolean translateWithPerfectMatchOnly;
     private Map<String, List<String>> fallbackLanguages;

--- a/src/main/java/com/crowdin/client/translations/model/ApplyPreTranslationStringsBasedRequest.java
+++ b/src/main/java/com/crowdin/client/translations/model/ApplyPreTranslationStringsBasedRequest.java
@@ -15,7 +15,15 @@ public class ApplyPreTranslationStringsBasedRequest {
     private AutoApproveOption autoApproveOption;
     private Boolean duplicateTranslations;
     private Boolean skipApprovedTranslations;
+    /**
+     * @deprecated use {@link #scope} instead; cannot be combined with {@code scope}.
+     */
+    @Deprecated
     private Boolean translateUntranslatedOnly;
+    private Scope scope;
+    private String translationModifiedBefore;
+    private ReplaceTranslationsOption replaceTranslationsOption;
+    private Boolean resetApprovalStatus;
     private Integer minimumMatchRatio;
     private Boolean translateWithPerfectMatchOnly;
     private List<FallbackLanguage> fallbackLanguages;

--- a/src/main/java/com/crowdin/client/translations/model/ReplaceTranslationsOption.java
+++ b/src/main/java/com/crowdin/client/translations/model/ReplaceTranslationsOption.java
@@ -1,0 +1,27 @@
+package com.crowdin.client.translations.model;
+
+import com.crowdin.client.core.model.EnumConverter;
+
+public enum ReplaceTranslationsOption implements EnumConverter<ReplaceTranslationsOption> {
+    NONE("none"), AUTO_TRANSLATED("autoTranslated"), ALL("all");
+
+    private final String value;
+
+    ReplaceTranslationsOption(String value) {
+        this.value = value;
+    }
+
+    public static ReplaceTranslationsOption from(String value) {
+        for (ReplaceTranslationsOption o : ReplaceTranslationsOption.values()) {
+            if (o.value.equals(value)) {
+                return o;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String to(ReplaceTranslationsOption v) {
+        return v.value;
+    }
+}

--- a/src/main/java/com/crowdin/client/translations/model/Scope.java
+++ b/src/main/java/com/crowdin/client/translations/model/Scope.java
@@ -1,0 +1,16 @@
+package com.crowdin.client.translations.model;
+
+import com.crowdin.client.core.model.EnumConverter;
+
+public enum Scope implements EnumConverter<Scope> {
+    UNTRANSLATED, TRANSLATED, ALL;
+
+    public static Scope from(String value) {
+        return Scope.valueOf(value.toUpperCase());
+    }
+
+    @Override
+    public String to(Scope v) {
+        return v.name().toLowerCase();
+    }
+}

--- a/src/test/java/com/crowdin/client/translations/TranslationsApiTest.java
+++ b/src/test/java/com/crowdin/client/translations/TranslationsApiTest.java
@@ -38,6 +38,8 @@ public class TranslationsApiTest extends TestClient {
         return Arrays.asList(
                 RequestMock.build(this.url + "/projects/" + projectId + "/pre-translations", HttpPost.METHOD_NAME, "api/translations/preTranslationRequest.json", "api/translations/preTranslationStatus.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/pre-translations", HttpPost.METHOD_NAME, "api/translations/preTranslationStringsBasedRequest.json", "api/translations/preTranslationStatusStringsBased.json"),
+                RequestMock.build(this.url + "/projects/" + projectId + "/pre-translations", HttpPost.METHOD_NAME, "api/translations/preTranslationScopeRequest.json", "api/translations/preTranslationStatus.json"),
+                RequestMock.build(this.url + "/projects/" + projectId + "/pre-translations", HttpPost.METHOD_NAME, "api/translations/preTranslationScopeStringsBasedRequest.json", "api/translations/preTranslationStatusStringsBased.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/pre-translations/" + preTranslationId, HttpGet.METHOD_NAME, "api/translations/preTranslationStatus.json"),
                 RequestMock.build(String.format("%s/projects/%d/translations/builds/directories/%d", this.url, projectId, directoryId), HttpPost.METHOD_NAME, "api/translations/buildProjectDirectoryRequest.json", "api/translations/downloadLink.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/translations/builds/files/" + fileId, HttpPost.METHOD_NAME, "api/translations/buildFileRequest.json", "api/translations/downloadLink.json"),
@@ -93,6 +95,34 @@ public class TranslationsApiTest extends TestClient {
 
         assertEquals(10000L, preTranslationStatusResponseObject.getData().getAttributes().getLabelIds().get(0));
         assertEquals(20000L, preTranslationStatusResponseObject.getData().getAttributes().getExcludeLabelIds().get(0));
+    }
+
+    @Test
+    public void applyPreTranslationScopeTest() {
+        ApplyPreTranslationRequest request = new ApplyPreTranslationRequest();
+        request.setLanguageIds(singletonList(language));
+        request.setFileIds(singletonList(fileId));
+        request.setMethod(Method.MT);
+        request.setScope(Scope.ALL);
+        request.setTranslationModifiedBefore("2024-01-01T00:00:00+00:00");
+        request.setReplaceTranslationsOption(ReplaceTranslationsOption.AUTO_TRANSLATED);
+        request.setResetApprovalStatus(true);
+        ResponseObject<PreTranslationStatus> preTranslationStatusResponseObject = this.getTranslationsApi().applyPreTranslation(projectId, request);
+        assertEquals(preTranslationStatusResponseObject.getData().getIdentifier(), preTranslationId);
+    }
+
+    @Test
+    public void applyPreTranslationScopeStringsBasedTest() {
+        ApplyPreTranslationStringsBasedRequest request = new ApplyPreTranslationStringsBasedRequest();
+        request.setLanguageIds(singletonList(language));
+        request.setBranchIds(singletonList(branchId));
+        request.setMethod(Method.MT);
+        request.setScope(Scope.ALL);
+        request.setTranslationModifiedBefore("2024-01-01T00:00:00+00:00");
+        request.setReplaceTranslationsOption(ReplaceTranslationsOption.AUTO_TRANSLATED);
+        request.setResetApprovalStatus(true);
+        ResponseObject<PreTranslationStatus> preTranslationStatusResponseObject = this.getTranslationsApi().applyPreTranslationStringsBased(projectId, request);
+        assertEquals(preTranslationStatusResponseObject.getData().getIdentifier(), preTranslationId);
     }
 
     @Test

--- a/src/test/resources/api/translations/preTranslationScopeRequest.json
+++ b/src/test/resources/api/translations/preTranslationScopeRequest.json
@@ -1,0 +1,13 @@
+{
+  "languageIds": [
+    "uk"
+  ],
+  "fileIds": [
+    2
+  ],
+  "method": "mt",
+  "scope": "all",
+  "translationModifiedBefore": "2024-01-01T00:00:00+00:00",
+  "replaceTranslationsOption": "autoTranslated",
+  "resetApprovalStatus": true
+}

--- a/src/test/resources/api/translations/preTranslationScopeStringsBasedRequest.json
+++ b/src/test/resources/api/translations/preTranslationScopeStringsBasedRequest.json
@@ -1,0 +1,13 @@
+{
+  "languageIds": [
+    "uk"
+  ],
+  "branchIds": [
+    211
+  ],
+  "method": "mt",
+  "scope": "all",
+  "translationModifiedBefore": "2024-01-01T00:00:00+00:00",
+  "replaceTranslationsOption": "autoTranslated",
+  "resetApprovalStatus": true
+}


### PR DESCRIPTION
Adds the new **Apply Pre-Translation** (`POST /projects/{projectId}/pre-translations`) re-translation control fields, as requested in #374, on both the file-based and strings-based request variants.

### New fields

- `scope` — `untranslated` (default), `translated`, or `all`, via a new `Scope` enum.
- `translationModifiedBefore` — re-translate only if the current translation was modified before this date.
- `replaceTranslationsOption` — `none` (default), `autoTranslated`, or `all`, via a new `ReplaceTranslationsOption` enum.
- `resetApprovalStatus` — remove approval on existing translations.

### Deprecation

- `translateUntranslatedOnly` is marked `@Deprecated` in favor of `scope` (the API deprecates it and disallows combining the two).

### Notes

- `translationModifiedBefore` is exposed as an ISO 8601 `String` (sent as-is) — happy to switch to `Date` if that's preferred.
- The new tests use an API-valid combination (e.g. `resetApprovalStatus` without `autoApproveOption`/`skipApprovedTranslations`, and `scope` without `translateUntranslatedOnly`).

### Tests

- Added `applyPreTranslationScopeTest` and `applyPreTranslationScopeStringsBasedTest` with request fixtures.
- `./gradlew test` passes.

Closes #374
