### PR TITLE
feat!: add projectDescription to AI prompt completions and remove assistActionAiPromptId

### DIFF
--- a/src/main/java/com/crowdin/client/ai/model/AiPromptCompletionRequest.java
+++ b/src/main/java/com/crowdin/client/ai/model/AiPromptCompletionRequest.java
@@ -20,5 +20,6 @@ public class AiPromptCompletionRequest {
         private List<Long> filteredStringsIds;
         private Map<String, Object> overridePromptValues;
         private String customInstruction;
+        private String projectDescription;
     }
 }

--- a/src/main/java/com/crowdin/client/ai/model/AiSetting.java
+++ b/src/main/java/com/crowdin/client/ai/model/AiSetting.java
@@ -7,7 +7,6 @@ import java.util.List;
 @Data
 public class AiSetting {
 
-    private Long assistActionAiPromptId;
     private Boolean showSuggestion;
     private Long editorSuggestionAiPromptId;
 

--- a/src/test/java/com/crowdin/client/ai/AIApiTest.java
+++ b/src/test/java/com/crowdin/client/ai/AIApiTest.java
@@ -330,7 +330,6 @@ public class AIApiTest extends TestClient {
     public void getAiSettingTest() {
         AiSetting aiSetting = this.getAiApi().getAiSetting(userId).getData();
         assertNotNull(aiSetting);
-        assertEquals(aiSetting.getAssistActionAiPromptId(), 2);
         assertEquals(aiSetting.getEditorSuggestionAiPromptId(), 5);
         assertEquals(aiSetting.getShortcuts().size(), 1);
     }
@@ -339,11 +338,10 @@ public class AIApiTest extends TestClient {
     public void editAiSettingTest() {
         PatchRequest request = new PatchRequest();
         request.setOp(PatchOperation.REPLACE);
-        request.setPath("/assistActionAiPromptId");
+        request.setPath("/editorSuggestionAiPromptId");
         ResponseObject<AiSetting> aiSettingResponseObject =
                 this.getAiApi().editAiSetting(userId, Collections.singletonList(request));
         assertNotNull(aiSettingResponseObject.getData());
-        assertEquals(aiSettingResponseObject.getData().getAssistActionAiPromptId(), 2);
         assertEquals(aiSettingResponseObject.getData().getEditorSuggestionAiPromptId(), 5);
     }
 
@@ -477,6 +475,7 @@ public class AIApiTest extends TestClient {
         AiPromptCompletionRequest aiPromptCompletionRequest = new AiPromptCompletionRequest();
         AiPromptCompletionRequest.AiPromptResource aiPromptResource = new AiPromptCompletionRequest.AiPromptResource();
         aiPromptResource.setProjectId(123L);
+        aiPromptResource.setProjectDescription("Mobile app project");
         aiPromptCompletionRequest.setResources(aiPromptResource);
         ResponseObject<AiPromptCompletionResponse.AiPromptCompletionData> response = this.getAiApi().generatePromptCompletion(userId, aiPromptId, aiPromptCompletionRequest);
         assertEquals(response.getData().getIdentifier(), completionId);

--- a/src/test/resources/api/ai/editAiSettingRequest.json
+++ b/src/test/resources/api/ai/editAiSettingRequest.json
@@ -1,6 +1,6 @@
 [
   {
     "op": "replace",
-    "path": "/assistActionAiPromptId"
+    "path": "/editorSuggestionAiPromptId"
   }
 ]

--- a/src/test/resources/api/ai/getAiSettingResponse.json
+++ b/src/test/resources/api/ai/getAiSettingResponse.json
@@ -1,6 +1,5 @@
 {
   "data": {
-    "assistActionAiPromptId": 2,
     "editorSuggestionAiPromptId": 5,
     "shortcuts": [
       {

--- a/src/test/resources/api/ai/promptCompletionRequest.json
+++ b/src/test/resources/api/ai/promptCompletionRequest.json
@@ -1,5 +1,6 @@
 {
   "resources": {
-    "projectId": 123
+    "projectId": 123,
+    "projectDescription": "Mobile app project"
   }
 }


### PR DESCRIPTION
Addresses #376 for the Java client, per the discussion on the issue.

- **Adds** `projectDescription` to the AI prompt completion resource (`AiPromptCompletionRequest.AiPromptResource`).
- **Removes** `assistActionAiPromptId` from `AiSetting`, now that the `assist` AI prompt action is gone (**breaking**).

The other parts of #376 (the `assist` action enum, override-prompt-values schemas, `projectContext` / `organizationContext`) don't require typed changes in this SDK, because the prompt `action`, `config`, and `overridePromptValues` are modeled as free-form `String` / `Map<String, Object>` (see my earlier note on the issue). The project-level `assistActionAiPromptId` on the Projects resource is left unchanged, as it's outside this issue's scope.

### Tests

- `generateAiPromptCompletionTest` now sets `projectDescription`; `getAiSettingTest` / `editAiSettingTest` updated for the removed field.
- `./gradlew test` passes.

Closes #376
