### PR TITLE
feat: migrate to Jackson 3

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
           cache: 'gradle'
 
       - name: Setup Gradle

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'temurin'
 
       - name: Build with Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ wrapper {
 }
 
 jacoco {
-    toolVersion = "0.8.5"
+    toolVersion = "0.8.11"
     reportsDir = file("$buildDir/reports")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.32'
 
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.3'
+    implementation platform('tools.jackson:jackson-bom:3.0.0')
+    implementation 'tools.jackson.core:jackson-databind'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0','org.mockito:mockito-core:4.11.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ task myJavadocs(type: Javadoc) {
     source = sourceSets.main.allJava
 }
 
-sourceCompatibility = 8
+sourceCompatibility = 17
 version '1.33.0'
 
 repositories {

--- a/src/main/java/com/crowdin/client/Sandbox.java
+++ b/src/main/java/com/crowdin/client/Sandbox.java
@@ -6,7 +6,6 @@ import com.crowdin.client.core.model.ClientConfig;
 import com.crowdin.client.core.model.Credentials;
 import com.crowdin.client.core.model.ResponseObject;
 import com.crowdin.client.users.model.User;
-import lombok.var;
 
 import java.io.FileNotFoundException;
 

--- a/src/main/java/com/crowdin/client/core/http/exceptions/HttpException.java
+++ b/src/main/java/com/crowdin/client/core/http/exceptions/HttpException.java
@@ -2,7 +2,6 @@ package com.crowdin.client.core.http.exceptions;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.var;
 
 @EqualsAndHashCode(callSuper = true)
 @Data

--- a/src/main/java/com/crowdin/client/core/http/impl/json/CrowdinApiExceptionDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/CrowdinApiExceptionDeserializer.java
@@ -10,7 +10,6 @@ import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.ValueDeserializer;
 import tools.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
 
 public class CrowdinApiExceptionDeserializer extends ValueDeserializer<CrowdinApiException> {
 

--- a/src/main/java/com/crowdin/client/core/http/impl/json/CrowdinApiExceptionDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/CrowdinApiExceptionDeserializer.java
@@ -4,15 +4,15 @@ import com.crowdin.client.core.http.exceptions.CrowdinApiException;
 import com.crowdin.client.core.http.exceptions.HttpBadRequestException;
 import com.crowdin.client.core.http.exceptions.HttpBatchBadRequestException;
 import com.crowdin.client.core.http.exceptions.HttpException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 
-public class CrowdinApiExceptionDeserializer extends JsonDeserializer<CrowdinApiException> {
+public class CrowdinApiExceptionDeserializer extends ValueDeserializer<CrowdinApiException> {
 
     private final ObjectMapper objectMapper;
 
@@ -21,12 +21,12 @@ public class CrowdinApiExceptionDeserializer extends JsonDeserializer<CrowdinApi
     }
 
     @Override
-    public CrowdinApiException deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        TreeNode treeNode = p.getCodec().readTree(p);
-        TreeNode errors = treeNode.get("errors");
+    public CrowdinApiException deserialize(JsonParser p, DeserializationContext ctxt) {
+        JsonNode treeNode = ctxt.readTree(p);
+        JsonNode errors = treeNode.get("errors");
 
         if (errors != null) {
-            TreeNode firstElement = errors.get(0);
+            JsonNode firstElement = errors.get(0);
 
             if (firstElement != null && firstElement.get("index") != null) {
                 return this.objectMapper.treeToValue(treeNode, HttpBatchBadRequestException.class);

--- a/src/main/java/com/crowdin/client/core/http/impl/json/DateDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/DateDeserializer.java
@@ -5,7 +5,6 @@ import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.ValueDeserializer;
 import lombok.SneakyThrows;
 
-import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 

--- a/src/main/java/com/crowdin/client/core/http/impl/json/DateDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/DateDeserializer.java
@@ -1,19 +1,19 @@
 package com.crowdin.client.core.http.impl.json;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
 import lombok.SneakyThrows;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-public class DateDeserializer extends JsonDeserializer<Date> {
+public class DateDeserializer extends ValueDeserializer<Date> {
 
     @Override
     @SneakyThrows
-    public Date deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    public Date deserialize(JsonParser p, DeserializationContext ctxt) {
         String date = p.getText();
         if (date == null || date.isEmpty()) {
             return null;

--- a/src/main/java/com/crowdin/client/core/http/impl/json/EmptyArrayToNullDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/EmptyArrayToNullDeserializer.java
@@ -5,7 +5,6 @@ import tools.jackson.core.JsonToken;
 import tools.jackson.databind.*;
 import tools.jackson.databind.deser.std.StdDeserializer;
 
-import java.io.IOException;
 import java.util.Collection;
 
 public class EmptyArrayToNullDeserializer extends StdDeserializer<Object> {

--- a/src/main/java/com/crowdin/client/core/http/impl/json/EmptyArrayToNullDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/EmptyArrayToNullDeserializer.java
@@ -1,15 +1,14 @@
 package com.crowdin.client.core.http.impl.json;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.*;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 import java.io.IOException;
 import java.util.Collection;
 
-public class EmptyArrayToNullDeserializer extends StdDeserializer<Object> implements ContextualDeserializer {
+public class EmptyArrayToNullDeserializer extends StdDeserializer<Object> {
     private JavaType type;
 
     public EmptyArrayToNullDeserializer() {
@@ -22,14 +21,14 @@ public class EmptyArrayToNullDeserializer extends StdDeserializer<Object> implem
     }
 
     @Override
-    public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        if (p.getCurrentToken() == JsonToken.VALUE_NULL) {
+    public Object deserialize(JsonParser p, DeserializationContext ctxt) {
+        if (p.currentToken() == JsonToken.VALUE_NULL) {
             return null;
         }
 
         Class<?> clazz = this.type != null ? this.type.getRawClass() : Object.class;
 
-        if (p.getCurrentToken() == JsonToken.START_ARRAY) {
+        if (p.currentToken() == JsonToken.START_ARRAY) {
             if (!isCollectionType(clazz)) {
                 p.nextToken();
                 return null;
@@ -46,7 +45,7 @@ public class EmptyArrayToNullDeserializer extends StdDeserializer<Object> implem
     }
 
     @Override
-    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
+    public ValueDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
         return new EmptyArrayToNullDeserializer(property.getType());
     }
 }

--- a/src/main/java/com/crowdin/client/core/http/impl/json/EnumDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/EnumDeserializer.java
@@ -1,19 +1,18 @@
 package com.crowdin.client.core.http.impl.json;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.BeanProperty;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.BeanProperty;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.DatabindException;
 import com.crowdin.client.core.model.EnumConverter;
 import lombok.SneakyThrows;
 
 import java.io.IOException;
 
-public class EnumDeserializer extends JsonDeserializer<Enum> implements ContextualDeserializer {
+public class EnumDeserializer extends ValueDeserializer<Enum> {
 
     private JavaType type;
 
@@ -25,7 +24,7 @@ public class EnumDeserializer extends JsonDeserializer<Enum> implements Contextu
     }
 
     @Override
-    public JsonDeserializer<?> createContextual(DeserializationContext deserializationContext, BeanProperty beanProperty) throws JsonMappingException {
+    public ValueDeserializer<?> createContextual(DeserializationContext deserializationContext, BeanProperty beanProperty) throws DatabindException {
         //beanProperty is null when the type to deserialize is the top-level type or a generic type, not a type of a bean property
         JavaType type = deserializationContext.getContextualType() != null
                 ? deserializationContext.getContextualType()
@@ -34,7 +33,7 @@ public class EnumDeserializer extends JsonDeserializer<Enum> implements Contextu
     }
 
     @Override
-    public Enum deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+    public Enum deserialize(JsonParser p, DeserializationContext ctxt) {
         String text = p.getText();
         return this.deserialize((Class<? extends Enum>) this.type.getRawClass(), text);
     }

--- a/src/main/java/com/crowdin/client/core/http/impl/json/EnumDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/EnumDeserializer.java
@@ -1,7 +1,6 @@
 package com.crowdin.client.core.http.impl.json;
 
 import tools.jackson.core.JsonParser;
-import tools.jackson.core.JacksonException;
 import tools.jackson.databind.BeanProperty;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.JavaType;
@@ -10,7 +9,6 @@ import tools.jackson.databind.DatabindException;
 import com.crowdin.client.core.model.EnumConverter;
 import lombok.SneakyThrows;
 
-import java.io.IOException;
 
 public class EnumDeserializer extends ValueDeserializer<Enum> {
 

--- a/src/main/java/com/crowdin/client/core/http/impl/json/EnumSerializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/EnumSerializer.java
@@ -6,7 +6,6 @@ import tools.jackson.databind.SerializationContext;
 import com.crowdin.client.core.model.EnumConverter;
 import lombok.SneakyThrows;
 
-import java.io.IOException;
 
 public class EnumSerializer extends ValueSerializer<Enum> {
     @Override

--- a/src/main/java/com/crowdin/client/core/http/impl/json/EnumSerializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/EnumSerializer.java
@@ -1,16 +1,16 @@
 package com.crowdin.client.core.http.impl.json;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.SerializationContext;
 import com.crowdin.client.core.model.EnumConverter;
 import lombok.SneakyThrows;
 
 import java.io.IOException;
 
-public class EnumSerializer extends JsonSerializer<Enum> {
+public class EnumSerializer extends ValueSerializer<Enum> {
     @Override
-    public void serialize(Enum value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(Enum value, JsonGenerator gen, SerializationContext serializers) {
         Object val;
         if (value instanceof EnumConverter) {
             val = this.serialize(value, EnumConverter.class.cast(value));

--- a/src/main/java/com/crowdin/client/core/http/impl/json/FileExportOptionsDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/FileExportOptionsDeserializer.java
@@ -4,19 +4,19 @@ import com.crowdin.client.sourcefiles.model.ExportOptions;
 import com.crowdin.client.sourcefiles.model.GeneralFileExportOptions;
 import com.crowdin.client.sourcefiles.model.JavaScriptFileExportOptions;
 import com.crowdin.client.sourcefiles.model.PropertyFileExportOptions;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-public class FileExportOptionsDeserializer extends JsonDeserializer<ExportOptions> {
+public class FileExportOptionsDeserializer extends ValueDeserializer<ExportOptions> {
 
     private final ObjectMapper objectMapper;
 
@@ -25,9 +25,9 @@ public class FileExportOptionsDeserializer extends JsonDeserializer<ExportOption
     }
 
     @Override
-    public ExportOptions deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-        TreeNode treeNode = p.getCodec().readTree(p);
-        Iterable<String> iterable = treeNode::fieldNames;
+    public ExportOptions deserialize(JsonParser p, DeserializationContext ctxt) {
+        JsonNode treeNode = ctxt.readTree(p);
+        Iterable<String> iterable = treeNode.propertyNames();
         List<String> fields = StreamSupport
                 .stream(iterable.spliterator(), false)
                 .collect(Collectors.toList());

--- a/src/main/java/com/crowdin/client/core/http/impl/json/FileExportOptionsDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/FileExportOptionsDeserializer.java
@@ -5,13 +5,11 @@ import com.crowdin.client.sourcefiles.model.GeneralFileExportOptions;
 import com.crowdin.client.sourcefiles.model.JavaScriptFileExportOptions;
 import com.crowdin.client.sourcefiles.model.PropertyFileExportOptions;
 import tools.jackson.core.JsonParser;
-import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.ValueDeserializer;
 import tools.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;

--- a/src/main/java/com/crowdin/client/core/http/impl/json/FileFormatSettingsDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/FileFormatSettingsDeserializer.java
@@ -7,7 +7,6 @@ import tools.jackson.databind.ValueDeserializer;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
 
 public class FileFormatSettingsDeserializer extends ValueDeserializer<FileFormatSettingsResource> {
 

--- a/src/main/java/com/crowdin/client/core/http/impl/json/FileFormatSettingsDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/FileFormatSettingsDeserializer.java
@@ -1,15 +1,15 @@
 package com.crowdin.client.core.http.impl.json;
 
 import com.crowdin.client.projectsgroups.model.*;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 
-public class FileFormatSettingsDeserializer extends JsonDeserializer<FileFormatSettingsResource> {
+public class FileFormatSettingsDeserializer extends ValueDeserializer<FileFormatSettingsResource> {
 
     private final ObjectMapper objectMapper;
 
@@ -18,8 +18,8 @@ public class FileFormatSettingsDeserializer extends JsonDeserializer<FileFormatS
     }
 
     @Override
-    public FileFormatSettingsResource deserialize(JsonParser parser, DeserializationContext ctx) throws IOException {
-        JsonNode parentNode = parser.getCodec().readTree(parser);
+    public FileFormatSettingsResource deserialize(JsonParser parser, DeserializationContext ctxt) {
+        JsonNode parentNode = ctxt.readTree(parser);
 
         FileFormatSettingsResource resource = this.objectMapper.readValue(parentNode.toString(), FileFormatSettingsResource.class);
 

--- a/src/main/java/com/crowdin/client/core/http/impl/json/FileImportOptionsDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/FileImportOptionsDeserializer.java
@@ -5,19 +5,19 @@ import com.crowdin.client.sourcefiles.model.ImportOptions;
 import com.crowdin.client.sourcefiles.model.OtherFileImportOptions;
 import com.crowdin.client.sourcefiles.model.SpreadsheetFileImportOptions;
 import com.crowdin.client.sourcefiles.model.XmlFileImportOptions;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-public class FileImportOptionsDeserializer extends JsonDeserializer<ImportOptions> {
+public class FileImportOptionsDeserializer extends ValueDeserializer<ImportOptions> {
 
     private final ObjectMapper objectMapper;
 
@@ -26,9 +26,9 @@ public class FileImportOptionsDeserializer extends JsonDeserializer<ImportOption
     }
 
     @Override
-    public ImportOptions deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-        TreeNode treeNode = p.getCodec().readTree(p);
-        Iterable<String> iterable = treeNode::fieldNames;
+    public ImportOptions deserialize(JsonParser p, DeserializationContext ctxt) {
+        JsonNode treeNode = ctxt.readTree(p);
+        Iterable<String> iterable = treeNode.propertyNames();
         List<String> fields = StreamSupport
                 .stream(iterable.spliterator(), false)
                 .collect(Collectors.toList());

--- a/src/main/java/com/crowdin/client/core/http/impl/json/FileImportOptionsDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/FileImportOptionsDeserializer.java
@@ -6,13 +6,11 @@ import com.crowdin.client.sourcefiles.model.OtherFileImportOptions;
 import com.crowdin.client.sourcefiles.model.SpreadsheetFileImportOptions;
 import com.crowdin.client.sourcefiles.model.XmlFileImportOptions;
 import tools.jackson.core.JsonParser;
-import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.ValueDeserializer;
 import tools.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;

--- a/src/main/java/com/crowdin/client/core/http/impl/json/FileInfoDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/FileInfoDeserializer.java
@@ -3,13 +3,11 @@ package com.crowdin.client.core.http.impl.json;
 import com.crowdin.client.sourcefiles.model.File;
 import com.crowdin.client.sourcefiles.model.FileInfo;
 import tools.jackson.core.JsonParser;
-import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.ValueDeserializer;
 import tools.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;

--- a/src/main/java/com/crowdin/client/core/http/impl/json/FileInfoDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/FileInfoDeserializer.java
@@ -2,19 +2,19 @@ package com.crowdin.client.core.http.impl.json;
 
 import com.crowdin.client.sourcefiles.model.File;
 import com.crowdin.client.sourcefiles.model.FileInfo;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-public class FileInfoDeserializer extends JsonDeserializer<FileInfo> {
+public class FileInfoDeserializer extends ValueDeserializer<FileInfo> {
 
     private final ObjectMapper objectMapper;
 
@@ -23,9 +23,9 @@ public class FileInfoDeserializer extends JsonDeserializer<FileInfo> {
     }
 
     @Override
-    public FileInfo deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-        TreeNode treeNode = p.getCodec().readTree(p);
-        Iterable<String> iterable = treeNode::fieldNames;
+    public FileInfo deserialize(JsonParser p, DeserializationContext ctxt) {
+        JsonNode treeNode = ctxt.readTree(p);
+        Iterable<String> iterable = treeNode.propertyNames();
         List<String> fields = StreamSupport
             .stream(iterable.spliterator(), false)
             .collect(Collectors.toList());

--- a/src/main/java/com/crowdin/client/core/http/impl/json/JacksonJsonTransformer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/JacksonJsonTransformer.java
@@ -14,10 +14,11 @@ import com.crowdin.client.stringtranslations.model.LanguageTranslations;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.databind.util.StdDateFormat;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.util.StdDateFormat;
 import lombok.SneakyThrows;
 
 import java.util.Date;
@@ -28,8 +29,9 @@ public class JacksonJsonTransformer implements JsonTransformer {
     private final ObjectMapper errorObjectMapper;
 
     public JacksonJsonTransformer() {
-        ObjectMapper cleanObjectMapper = new ObjectMapper()
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        ObjectMapper cleanObjectMapper = JsonMapper.builder()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .build();
         SimpleModule enumModule = new SimpleModule()
             .addDeserializer(Enum.class, new EnumDeserializer());
 
@@ -38,22 +40,26 @@ public class JacksonJsonTransformer implements JsonTransformer {
             .addSerializer(Enum.class, new EnumSerializer())
             .addDeserializer(Enum.class, new EnumDeserializer())
             .addDeserializer(CrowdinApiException.class, new CrowdinApiExceptionDeserializer(cleanObjectMapper))
-            .addDeserializer(Project.class, new ProjectDeserializer(cleanObjectMapper.copy()
-                .registerModule(enumModule)))
-            .addDeserializer(FileInfo.class, new FileInfoDeserializer(cleanObjectMapper.copy()
-                .registerModule(enumModule)
-                .registerModule(new SimpleModule()
+            .addDeserializer(Project.class, new ProjectDeserializer(cleanObjectMapper.rebuild()
+                .addModule(enumModule)
+                .build()))
+            .addDeserializer(FileInfo.class, new FileInfoDeserializer(cleanObjectMapper.rebuild()
+                .addModule(enumModule)
+                .addModule(new SimpleModule()
                     .addDeserializer(ImportOptions.class, new FileImportOptionsDeserializer(cleanObjectMapper))
-                    .addDeserializer(ExportOptions.class, new FileExportOptionsDeserializer(cleanObjectMapper)))))
+                    .addDeserializer(ExportOptions.class, new FileExportOptionsDeserializer(cleanObjectMapper)))
+                .build()))
             .addDeserializer(LanguageTranslations.class, new LanguageTranslationsDeserializer(cleanObjectMapper))
             .addDeserializer(FileFormatSettingsResource.class, new FileFormatSettingsDeserializer(cleanObjectMapper))
             .addDeserializer(StringsExporterSettingsResource.class, new StringsExporterSettingsDeserializer(cleanObjectMapper));
-        this.objectMapper = cleanObjectMapper.copy()
-                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                .setDateFormat(new StdDateFormat())
-                .registerModule(module)
-                .setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE)
-                .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+        this.objectMapper = cleanObjectMapper.rebuild()
+                .changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL))
+                .defaultDateFormat(new StdDateFormat())
+                .addModule(module)
+                .changeDefaultVisibility(vc -> vc
+                    .withVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE)
+                    .withVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY))
+                .build();
         this.errorObjectMapper = cleanObjectMapper;
     }
 

--- a/src/main/java/com/crowdin/client/core/http/impl/json/LanguageTranslationsDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/LanguageTranslationsDeserializer.java
@@ -5,13 +5,11 @@ import com.crowdin.client.stringtranslations.model.LanguageTranslations;
 import com.crowdin.client.stringtranslations.model.PlainLanguageTranslations;
 import com.crowdin.client.stringtranslations.model.PluralLanguageTranslations;
 import tools.jackson.core.JsonParser;
-import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.ValueDeserializer;
 import tools.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;

--- a/src/main/java/com/crowdin/client/core/http/impl/json/LanguageTranslationsDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/LanguageTranslationsDeserializer.java
@@ -4,19 +4,19 @@ import com.crowdin.client.stringtranslations.model.ICULanguageTranslations;
 import com.crowdin.client.stringtranslations.model.LanguageTranslations;
 import com.crowdin.client.stringtranslations.model.PlainLanguageTranslations;
 import com.crowdin.client.stringtranslations.model.PluralLanguageTranslations;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-public class LanguageTranslationsDeserializer extends JsonDeserializer<LanguageTranslations> {
+public class LanguageTranslationsDeserializer extends ValueDeserializer<LanguageTranslations> {
 
     private final ObjectMapper objectMapper;
 
@@ -25,9 +25,9 @@ public class LanguageTranslationsDeserializer extends JsonDeserializer<LanguageT
     }
 
     @Override
-    public LanguageTranslations deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-        TreeNode treeNode = p.getCodec().readTree(p);
-        Iterable<String> iterable = treeNode::fieldNames;
+    public LanguageTranslations deserialize(JsonParser p, DeserializationContext ctxt) {
+        JsonNode treeNode = ctxt.readTree(p);
+        Iterable<String> iterable = treeNode.propertyNames();
         List<String> fields = StreamSupport
             .stream(iterable.spliterator(), false)
             .collect(Collectors.toList());

--- a/src/main/java/com/crowdin/client/core/http/impl/json/ProjectDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/ProjectDeserializer.java
@@ -3,13 +3,11 @@ package com.crowdin.client.core.http.impl.json;
 import com.crowdin.client.projectsgroups.model.Project;
 import com.crowdin.client.projectsgroups.model.ProjectSettings;
 import tools.jackson.core.JsonParser;
-import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.ValueDeserializer;
 import tools.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;

--- a/src/main/java/com/crowdin/client/core/http/impl/json/ProjectDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/ProjectDeserializer.java
@@ -2,19 +2,19 @@ package com.crowdin.client.core.http.impl.json;
 
 import com.crowdin.client.projectsgroups.model.Project;
 import com.crowdin.client.projectsgroups.model.ProjectSettings;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-public class ProjectDeserializer extends JsonDeserializer<Project> {
+public class ProjectDeserializer extends ValueDeserializer<Project> {
 
     private final ObjectMapper objectMapper;
 
@@ -23,9 +23,9 @@ public class ProjectDeserializer extends JsonDeserializer<Project> {
     }
 
     @Override
-    public Project deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-        TreeNode treeNode = p.getCodec().readTree(p);
-        Iterable<String> iterable = treeNode::fieldNames;
+    public Project deserialize(JsonParser p, DeserializationContext ctxt) {
+        JsonNode treeNode = ctxt.readTree(p);
+        Iterable<String> iterable = treeNode.propertyNames();
         List<String> fields = StreamSupport
                 .stream(iterable.spliterator(), false)
                 .collect(Collectors.toList());

--- a/src/main/java/com/crowdin/client/core/http/impl/json/StringsExporterSettingsDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/StringsExporterSettingsDeserializer.java
@@ -12,7 +12,6 @@ import tools.jackson.databind.ValueDeserializer;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
 
 public class StringsExporterSettingsDeserializer extends ValueDeserializer<StringsExporterSettingsResource> {
 

--- a/src/main/java/com/crowdin/client/core/http/impl/json/StringsExporterSettingsDeserializer.java
+++ b/src/main/java/com/crowdin/client/core/http/impl/json/StringsExporterSettingsDeserializer.java
@@ -6,15 +6,15 @@ import com.crowdin.client.projectsgroups.model.StringsExporterSettings;
 import com.crowdin.client.projectsgroups.model.StringsExporterSettingsResource;
 import com.crowdin.client.projectsgroups.model.XliffStringsExporterSettings;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 
-public class StringsExporterSettingsDeserializer extends JsonDeserializer<StringsExporterSettingsResource> {
+public class StringsExporterSettingsDeserializer extends ValueDeserializer<StringsExporterSettingsResource> {
 
     private final ObjectMapper objectMapper;
 
@@ -23,8 +23,8 @@ public class StringsExporterSettingsDeserializer extends JsonDeserializer<String
     }
 
     @Override
-    public StringsExporterSettingsResource deserialize(JsonParser parser, DeserializationContext ctxt) throws IOException {
-        JsonNode parentNode = parser.getCodec().readTree(parser);
+    public StringsExporterSettingsResource deserialize(JsonParser parser, DeserializationContext ctxt) {
+        JsonNode parentNode = ctxt.readTree(parser);
 
         StringsExporterSettingsResource resource =
                 this.objectMapper.readValue(parentNode.toString(), StringsExporterSettingsResource.class);

--- a/src/main/java/com/crowdin/client/projectsgroups/model/ProjectSettings.java
+++ b/src/main/java/com/crowdin/client/projectsgroups/model/ProjectSettings.java
@@ -2,7 +2,7 @@ package com.crowdin.client.projectsgroups.model;
 
 import com.crowdin.client.core.http.impl.json.EmptyArrayToNullDeserializer;
 import com.crowdin.client.languages.model.Language;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;

--- a/src/main/java/com/crowdin/client/sourcestrings/model/UploadStringsProgress.java
+++ b/src/main/java/com/crowdin/client/sourcestrings/model/UploadStringsProgress.java
@@ -2,7 +2,7 @@ package com.crowdin.client.sourcestrings.model;
 
 import com.crowdin.client.core.http.impl.json.EmptyArrayToNullDeserializer;
 import com.crowdin.client.sourcefiles.model.UpdateOption;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 import lombok.Data;
 
 import java.util.Date;

--- a/src/main/java/com/crowdin/client/translations/model/ImportTranslationsReportResponse.java
+++ b/src/main/java/com/crowdin/client/translations/model/ImportTranslationsReportResponse.java
@@ -1,7 +1,7 @@
 package com.crowdin.client.translations.model;
 
 import com.crowdin.client.core.http.impl.json.EmptyArrayToNullDeserializer;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 import lombok.Data;
 
 import java.util.List;

--- a/src/main/java/com/crowdin/client/translations/model/ImportTranslationsStringsBasedReportResponse.java
+++ b/src/main/java/com/crowdin/client/translations/model/ImportTranslationsStringsBasedReportResponse.java
@@ -1,7 +1,7 @@
 package com.crowdin.client.translations.model;
 
 import com.crowdin.client.core.http.impl.json.EmptyArrayToNullDeserializer;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 import lombok.Data;
 
 import java.util.List;

--- a/src/main/java/com/crowdin/client/translations/model/PreTranslationReportResponse.java
+++ b/src/main/java/com/crowdin/client/translations/model/PreTranslationReportResponse.java
@@ -1,7 +1,7 @@
 package com.crowdin.client.translations.model;
 
 import com.crowdin.client.core.http.impl.json.EmptyArrayToNullDeserializer;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 import lombok.Data;
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/com/crowdin/client/core/CrowdinApiTest.java
+++ b/src/test/java/com/crowdin/client/core/CrowdinApiTest.java
@@ -4,7 +4,6 @@ import com.crowdin.client.core.model.GraphQLRequest;
 import com.crowdin.client.framework.RequestMock;
 import com.crowdin.client.framework.TestClient;
 import lombok.Data;
-import lombok.var;
 import org.apache.http.client.methods.HttpPost;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/crowdin/client/core/http/impl/json/CrowdinApiExceptionDeserializerTest.java
+++ b/src/test/java/com/crowdin/client/core/http/impl/json/CrowdinApiExceptionDeserializerTest.java
@@ -4,9 +4,9 @@ import com.crowdin.client.core.http.exceptions.CrowdinApiException;
 import com.crowdin.client.core.http.exceptions.HttpBadRequestException;
 import com.crowdin.client.core.http.exceptions.HttpBatchBadRequestException;
 import com.crowdin.client.core.http.exceptions.HttpException;
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -68,12 +68,12 @@ public class CrowdinApiExceptionDeserializerTest {
     }
 
     private void testDeserialize(String json, Class<? extends CrowdinApiException> expectedExceptionClass) throws IOException {
-        ObjectMapper objectMapper = new ObjectMapper();
-        CrowdinApiExceptionDeserializer deserializer = new CrowdinApiExceptionDeserializer(objectMapper);
-        JsonParser parser = new JsonFactory().createParser(json);
-        parser.setCodec(objectMapper);
+        ObjectMapper objectMapper = JsonMapper.builder()
+                .addModule(new SimpleModule().addDeserializer(
+                        CrowdinApiException.class, new CrowdinApiExceptionDeserializer(new ObjectMapper())))
+                .build();
 
-        CrowdinApiException exception = deserializer.deserialize(parser, null);
+        CrowdinApiException exception = objectMapper.readValue(json, CrowdinApiException.class);
 
         assertTrue(expectedExceptionClass.isInstance(exception));
     }

--- a/src/test/java/com/crowdin/client/core/http/impl/json/EmptyArrayToNullDeserializerTest.java
+++ b/src/test/java/com/crowdin/client/core/http/impl/json/EmptyArrayToNullDeserializerTest.java
@@ -1,12 +1,12 @@
 package com.crowdin.client.core.http.impl.json;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.type.TypeFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -52,7 +52,7 @@ public class EmptyArrayToNullDeserializerTest {
 
         // Setting up behavior of mocked objects
         when(jsonFactory.createParser(errorsResponse)).thenReturn(jsonParser);
-        when(jsonParser.getCurrentToken()).thenReturn(JsonToken.VALUE_NULL);
+        when(jsonParser.currentToken()).thenReturn(JsonToken.VALUE_NULL);
         when(deserializationContext.readValue(jsonParser, Object.class)).thenReturn("value");
 
         // Creating an instance of your deserializer
@@ -83,7 +83,7 @@ public class EmptyArrayToNullDeserializerTest {
 
         // Setting up behavior of mocked objects
         when(jsonFactory.createParser(errorsResponse)).thenReturn(jsonParser);
-        when(jsonParser.getCurrentToken()).thenReturn(JsonToken.START_ARRAY);
+        when(jsonParser.currentToken()).thenReturn(JsonToken.START_ARRAY);
         when(deserializationContext.readValue(jsonParser, Object.class)).thenReturn("value");
 
         // Creating an instance of your deserializer
@@ -115,7 +115,7 @@ public class EmptyArrayToNullDeserializerTest {
 
         // Setting up behavior of mocked objects
         when(jsonFactory.createParser(errorsResponse)).thenReturn(jsonParser);
-        when(jsonParser.getCurrentToken()).thenReturn(JsonToken.START_ARRAY);
+        when(jsonParser.currentToken()).thenReturn(JsonToken.START_ARRAY);
         when(deserializationContext.readValue(jsonParser, Object.class)).thenReturn("value");
 
         // Creating an instance of your deserializer
@@ -138,7 +138,7 @@ public class EmptyArrayToNullDeserializerTest {
 
         // Setting up behavior of mocked objects
         when(jsonFactory.createParser(errorsResponse)).thenReturn(jsonParser);
-        when(jsonParser.getCurrentToken()).thenReturn(JsonToken.START_ARRAY);
+        when(jsonParser.currentToken()).thenReturn(JsonToken.START_ARRAY);
         when(deserializationContext.readValue(jsonParser, Object.class)).thenReturn("value");
 
         // Creating an instance of your deserializer

--- a/src/test/java/com/crowdin/client/core/http/impl/json/FileFormatSettingsDeserializerTest.java
+++ b/src/test/java/com/crowdin/client/core/http/impl/json/FileFormatSettingsDeserializerTest.java
@@ -90,7 +90,7 @@ public class FileFormatSettingsDeserializerTest {
         String json = rootNode.toString();
 
         // Assertions
-        assertThrows(Exception.class, () -> mapper.readValue(json, FileFormatSettingsResource.class));
+        assertThrows(NullPointerException.class, () -> mapper.readValue(json, FileFormatSettingsResource.class));
     }
 
     public static String replaceFormat(String json, String newFormat) throws IOException {

--- a/src/test/java/com/crowdin/client/core/http/impl/json/FileFormatSettingsDeserializerTest.java
+++ b/src/test/java/com/crowdin/client/core/http/impl/json/FileFormatSettingsDeserializerTest.java
@@ -1,11 +1,11 @@
 package com.crowdin.client.core.http.impl.json;
 
 import com.crowdin.client.projectsgroups.model.*;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -54,12 +54,15 @@ public class FileFormatSettingsDeserializerTest {
         ));
 
 
+        ObjectMapper mapper = JsonMapper.builder()
+                .addModule(new SimpleModule().addDeserializer(
+                        FileFormatSettingsResource.class, new FileFormatSettingsDeserializer(new ObjectMapper())))
+                .build();
+
         formats.forEach(f -> {
             try {
                 String newJson = replaceFormat(deserializeObjectExample, f);
-                JsonParser jsonParser = objectMapper.getFactory().createParser(newJson);
-                DeserializationContext deserializationContext = objectMapper.getDeserializationContext();
-                FileFormatSettingsResource result = deserializer.deserialize(jsonParser, deserializationContext);
+                FileFormatSettingsResource result = mapper.readValue(newJson, FileFormatSettingsResource.class);
                 assertion(f, result);
             } catch (IOException e) {
                 throw new RuntimeException(e);
@@ -80,11 +83,14 @@ public class FileFormatSettingsDeserializerTest {
         // Prepare a JSON object with null parent node
         ObjectNode rootNode = objectMapper.createObjectNode();
         rootNode.putNull("format"); // Simulating null parent node
-        JsonParser jsonParser = objectMapper.treeAsTokens(rootNode);
-        DeserializationContext deserializationContext = objectMapper.getDeserializationContext();
+        ObjectMapper mapper = JsonMapper.builder()
+                .addModule(new SimpleModule().addDeserializer(
+                        FileFormatSettingsResource.class, new FileFormatSettingsDeserializer(new ObjectMapper())))
+                .build();
+        String json = rootNode.toString();
 
         // Assertions
-        assertThrows(NullPointerException.class, () -> deserializer.deserialize(jsonParser, deserializationContext));
+        assertThrows(Exception.class, () -> mapper.readValue(json, FileFormatSettingsResource.class));
     }
 
     public static String replaceFormat(String json, String newFormat) throws IOException {

--- a/src/test/java/com/crowdin/client/framework/TestHttpClient.java
+++ b/src/test/java/com/crowdin/client/framework/TestHttpClient.java
@@ -5,7 +5,7 @@ import com.crowdin.client.core.http.HttpRequestConfig;
 import com.crowdin.client.core.http.exceptions.HttpBadRequestException;
 import com.crowdin.client.core.http.exceptions.HttpException;
 import com.crowdin.client.core.http.impl.json.JacksonJsonTransformer;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;

--- a/src/test/resources/api/ai/generateAiReportRequest.json
+++ b/src/test/resources/api/ai/generateAiReportRequest.json
@@ -1,8 +1,8 @@
 {
   "type": "tokens-usage-raw-data",
   "schema": {
-    "dateFrom": "2019-09-23T11:26:54.000+00:00",
-    "dateTo": "2019-09-23T11:26:54.000+00:00",
+    "dateFrom": "2019-09-23T11:26:54.000Z",
+    "dateTo": "2019-09-23T11:26:54.000Z",
     "format": "json",
     "projectIds": [
       0


### PR DESCRIPTION
## Purpose

Migrates the SDK from **Jackson 2.17.3 to Jackson 3.0.0**, as requested in #370.

> ⚠️ **Jackson 3 requires Java 17.** This PR therefore bumps the project baseline from Java 8 to **Java 17** (`build.gradle` + CI workflows), which **drops Java 8/11 support**. That is an inherent consequence of Jackson 3 and a release-level decision — flagging it explicitly.

## What changed

- **`build.gradle`**: switched to the `tools.jackson` BOM (`jackson-databind` 3.0.0). `jackson-annotations` intentionally stays under `com.fasterxml.jackson` (Jackson 3 keeps the annotations package).
- **Java baseline → 17**: `sourceCompatibility` bumped 8 → 17 and the CI workflows (`basic.yml`, `docs.yml`) bumped to Java 17 (Jackson 3's minimum). Removed `import lombok.var;` (3 files) in favor of native `var`.
- **Imports**: `com.fasterxml.jackson.{core,databind}.*` → `tools.jackson.*` (annotations untouched; `JsonFactory` moved to `tools.jackson.core.json`).
- **`JacksonJsonTransformer`**: `ObjectMapper` is immutable in 3.x, so the mapper is built with `JsonMapper.builder()` (`configure`, `changeDefaultPropertyInclusion(NON_NULL)`, `defaultDateFormat`, `addModule`, `changeDefaultVisibility`); derived mappers use `rebuild()` instead of `copy()`.
- **Custom (de)serializers**:
  - `JsonSerializer`/`JsonDeserializer` → `ValueSerializer`/`ValueDeserializer`
  - `SerializerProvider` → `SerializationContext`
  - `ContextualDeserializer` removed — `createContextual` is now declared on `ValueDeserializer`
  - `p.getCodec().readTree(p)` → `ctxt.readTree(p)`; `getCurrentToken()` → `currentToken()`; `node.fieldNames()` → `propertyNames()`
  - dropped `throws IOException` (Jackson exceptions are unchecked in 3.x)
- **Tests**: the deserializer unit tests relied on Jackson 2 internals that were removed in 3.x (`JsonParser.setCodec`, `ObjectMapper.getFactory`, `ObjectMapper.getDeserializationContext`). They were rewritten to drive deserialization through a configured mapper (`readValue`), preserving the same assertions.

## Heads-up (behavioral change)

Jackson 3's `StdDateFormat` serializes UTC dates as `...Z` (canonical ISO-8601) instead of `...+00:00`. For example `2019-09-23T11:26:54.000+00:00` → `2019-09-23T11:26:54.000Z`. The affected request fixture was updated. There is no built-in option in Jackson 3's `StdDateFormat` to restore the `+00:00` form; both are valid ISO-8601.

## Testing

All **579 tests pass** locally (`./gradlew test`, JDK 17).

This is a breaking change (**requires Java 17**, new `tools.jackson` coordinates, and the date-format note above), so it's presumably for the next major release — happy to align on timing/approach.

Closes #370
