### PR TITLE
feat: add organization-level search endpoints for projects

### DIFF
--- a/src/main/java/com/crowdin/client/sourcefiles/SourceFilesApi.java
+++ b/src/main/java/com/crowdin/client/sourcefiles/SourceFilesApi.java
@@ -120,6 +120,31 @@ public class SourceFilesApi extends CrowdinApi {
     }
 
     /**
+     * @param filter search branches by name or title
+     * @param projectIds project identifiers (max 50)
+     * @param userId owner identifier
+     * @param limit maximum number of items to retrieve (default 25)
+     * @param offset a starting offset in the collection
+     * @return branches by name or title
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.branches.getMany" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.branches.getMany" target="_blank"><b>API Enterprise Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseList<Branch> searchBranches(String filter, String projectIds, Integer userId, Integer limit, Integer offset) throws HttpException, HttpBadRequestException {
+        Map<String, Optional<Object>> queryParams = HttpRequestConfig.buildUrlParams(
+                "filter", Optional.of(filter),
+                "projectIds", Optional.ofNullable(projectIds),
+                "userId", Optional.ofNullable(userId),
+                "limit", Optional.ofNullable(limit),
+                "offset", Optional.ofNullable(offset)
+        );
+
+        BranchResponseList branchResponseList = this.httpClient.get(this.url + "/branches", new HttpRequestConfig(queryParams), BranchResponseList.class);
+        return BranchResponseList.to(branchResponseList);
+    }
+
+    /**
      * @param projectId project identifier
      * @param branchId filter by branch id
      * @param directoryId filter by directory id
@@ -228,6 +253,31 @@ public class SourceFilesApi extends CrowdinApi {
     public ResponseObject<Directory> editDirectory(Long projectId, Long directoryId, List<PatchRequest> request) throws HttpException, HttpBadRequestException {
         DirectoryResponseObject directoryResponseObject = this.httpClient.patch(this.url + "/projects/" + projectId + "/directories/" + directoryId, request, new HttpRequestConfig(), DirectoryResponseObject.class);
         return ResponseObject.of(directoryResponseObject.getData());
+    }
+
+    /**
+     * @param filter search directories by name or title
+     * @param projectIds project identifiers (max 50)
+     * @param userId owner identifier
+     * @param limit maximum number of items to retrieve (default 25)
+     * @param offset a starting offset in the collection
+     * @return directories by name or title
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.directories.getMany" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.directories.getMany" target="_blank"><b>API Enterprise Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseList<Directory> searchDirectories(String filter, String projectIds, Integer userId, Integer limit, Integer offset) throws HttpException, HttpBadRequestException {
+        Map<String, Optional<Object>> queryParams = HttpRequestConfig.buildUrlParams(
+                "filter", Optional.of(filter),
+                "projectIds", Optional.ofNullable(projectIds),
+                "userId", Optional.ofNullable(userId),
+                "limit", Optional.ofNullable(limit),
+                "offset", Optional.ofNullable(offset)
+        );
+
+        DirectoryResponseList directoryResponseList = this.httpClient.get(this.url + "/directories", new HttpRequestConfig(queryParams), DirectoryResponseList.class);
+        return DirectoryResponseList.to(directoryResponseList);
     }
 
     /**
@@ -482,6 +532,30 @@ public class SourceFilesApi extends CrowdinApi {
         return ResponseObject.of(downloadLinkResponseObject.getData());
     }
 
+    /**
+     * @param filter search files by name or title
+     * @param projectIds project identifiers (max 50)
+     * @param userId owner identifier
+     * @param limit maximum number of items to retrieve (default 25)
+     * @param offset a starting offset in the collection
+     * @return files by name or title
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.files.getMany" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.files.getMany" target="_blank"><b>API Enterprise Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseList<? extends FileInfo> searchFiles(String filter, String projectIds, Integer userId, Integer limit, Integer offset) throws HttpException, HttpBadRequestException {
+        Map<String, Optional<Object>> queryParams = HttpRequestConfig.buildUrlParams(
+                "filter", Optional.of(filter),
+                "projectIds", Optional.ofNullable(projectIds),
+                "userId", Optional.ofNullable(userId),
+                "limit", Optional.ofNullable(limit),
+                "offset", Optional.ofNullable(offset)
+        );
+
+        FileInfoResponseList fileInfoResponseList = this.httpClient.get(this.url + "/files", new HttpRequestConfig(queryParams), FileInfoResponseList.class);
+        return FileInfoResponseList.to(fileInfoResponseList);
+    }
     /**
      * @param projectId project identifier
      * @param fileId file identifier

--- a/src/main/java/com/crowdin/client/sourcestrings/SourceStringsApi.java
+++ b/src/main/java/com/crowdin/client/sourcestrings/SourceStringsApi.java
@@ -189,6 +189,35 @@ public class SourceStringsApi extends CrowdinApi {
     }
 
     /**
+     * @param filter search strings by the fields selected in scope
+     * @param projectIds project identifiers (max 50)
+     * @param userId owner identifier
+     * @param scope specify field to be the target of filtering (default all)
+     * @param denormalizePlaceholders enable denormalize placeholders (default 0)
+     * @param limit maximum numbers of items to retrieve (max 25)
+     * @param offset a starting offset in the collection
+     * @return source strings by text/context/key
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.strings.getMany" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.strings.getMany" target="_blank"><b>API Enterprise Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseList<SourceString> searchSourceStrings(String filter, String projectIds, Integer userId, String scope, Integer denormalizePlaceholders, Integer limit, Integer offset) throws HttpException, HttpBadRequestException {
+        Map<String, Optional<Object>> queryParams = HttpRequestConfig.buildUrlParams(
+                "filter", Optional.of(filter),
+                "projectIds", Optional.ofNullable(projectIds),
+                "userId", Optional.ofNullable(userId),
+                "scope", Optional.ofNullable(scope),
+                "denormalizePlaceholders", Optional.ofNullable(denormalizePlaceholders),
+                "limit", Optional.ofNullable(limit),
+                "offset", Optional.ofNullable(offset)
+        );
+
+        SourceStringResponseList sourceStringResponseList = this.httpClient.get(this.url + "/strings", new HttpRequestConfig(queryParams), SourceStringResponseList.class);
+        return SourceStringResponseList.to(sourceStringResponseList);
+    }
+
+    /**
      * @param projectId project identifier
      * @param request request object
      * @return list of updated source strings

--- a/src/main/java/com/crowdin/client/stringtranslations/StringTranslationsApi.java
+++ b/src/main/java/com/crowdin/client/stringtranslations/StringTranslationsApi.java
@@ -418,6 +418,35 @@ public class StringTranslationsApi extends CrowdinApi {
     }
 
     /**
+     * @param filter search translations by text
+     * @param projectIds project identifiers (max 50)
+     * @param userId owner identifier
+     * @param languageIds target language identifier
+     * @param denormalizePlaceholders enable denormalize placeholders (default 0)
+     * @param limit maximum numbers of items to retrieve (max 25)
+     * @param offset a starting offset in the collection
+     * @return target-language translations by text
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.translations.getMany" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.translations.getMany" target="_blank"><b>API Enterprise Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseList<StringTranslation> searchTranslations(String filter, String projectIds, Integer userId, String languageIds, Integer denormalizePlaceholders, Integer limit, Integer offset) throws HttpException, HttpBadRequestException {
+        Map<String, Optional<Object>> queryParams = HttpRequestConfig.buildUrlParams(
+                "filter", Optional.of(filter),
+                "projectIds", Optional.ofNullable(projectIds),
+                "userId", Optional.ofNullable(userId),
+                "languageIds", Optional.ofNullable(languageIds),
+                "denormalizePlaceholders", Optional.ofNullable(denormalizePlaceholders),
+                "limit", Optional.ofNullable(limit),
+                "offset", Optional.ofNullable(offset)
+        );
+
+        StringTranslationResponseList stringTranslationResponseList = this.httpClient.get(this.url + "/translations", new HttpRequestConfig(queryParams), StringTranslationResponseList.class);
+        return StringTranslationResponseList.to(stringTranslationResponseList);
+    }
+
+    /**
      * @param projectId project identifier
      * @param stringId string identifier
      * @param languageId language identifier

--- a/src/test/java/com/crowdin/client/sourcefiles/SourceFilesApiTest.java
+++ b/src/test/java/com/crowdin/client/sourcefiles/SourceFilesApiTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class SourceFilesApiTest extends TestClient {
 
+    private final Integer userId = 4;
     private final Long branchId = 34L;
     private final Long branch2Id = 35L;
     private final Long directoryId = 4L;
@@ -33,21 +34,27 @@ public class SourceFilesApiTest extends TestClient {
     private final Long project2Id = 4L;
     private final Long project3Id = 5L;
     private final Long project4Id = 6L;
+    private final Long project5Id = 2L;
     private final Long fileId = 44L;
     private final Long storageId = 61L;
     private final Long referenceId = 123L;
     private final Long fileRevisionId = 2L;
     private final Long buildId = 42L;
     private final String branchName = "develop-master";
+    private final String branchTitle = "Master branch";
     private final String sequentBranchName1 = "develop-master-#1";
     private final String sequentBranchName2 = "develop-master-#2";
     private final String directoryName = "main";
     private final String directory2Name = "main-#2";
+    private final String directoryTitle = "<Description materials>";
     private final String fileName = "umbrella_app.xliff";
     private final String referenceName = "design_reference.png";
     private final String context = "Context for translators";
     private final String downloadLink = "test.com";
     private final String status = "finished";
+    private final String exportPattern = "%three_letters_code%";
+    private final String priority = "normal";
+    private final String projectIds = "1,2,3";
     private final List<Long> attachLabelIds = Arrays.asList(1L);
     private final List<Long> detachLabelIds = attachLabelIds;
     private final TimeZone tz = TimeZone.getTimeZone("GMT");
@@ -66,6 +73,10 @@ public class SourceFilesApiTest extends TestClient {
                 RequestMock.build(this.url + "/projects/" + projectId + "/branches/" + branchId, HttpGet.METHOD_NAME, "api/sourcefiles/branch.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/branches/" + branchId, HttpDelete.METHOD_NAME),
                 RequestMock.build(this.url + "/projects/" + projectId + "/branches/" + branchId, HttpPatch.METHOD_NAME, "api/sourcefiles/editBranch.json", "api/sourcefiles/branch.json"),
+                RequestMock.build(this.url + "/branches", HttpGet.METHOD_NAME, "api/sourcefiles/searchBranches.json", new HashMap<String, String>() {{
+                    put("filter", branchName);
+                    put("projectIds", projectIds);
+                }}),
                 RequestMock.build(this.url + "/projects/" + projectId + "/directories", HttpGet.METHOD_NAME, "api/sourcefiles/listDirectories.json"),
                 RequestMock.build(this.url + "/projects/" + project3Id + "/directories", HttpGet.METHOD_NAME, "api/sourcefiles/listDirectoriesOrderByIdAsc.json",  new HashMap<String, String>() {{
                     put("orderBy", "id%20asc");
@@ -77,6 +88,10 @@ public class SourceFilesApiTest extends TestClient {
                 RequestMock.build(this.url + "/projects/" + projectId + "/directories/" + directoryId, HttpGet.METHOD_NAME, "api/sourcefiles/directory.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/directories/" + directoryId, HttpDelete.METHOD_NAME),
                 RequestMock.build(this.url + "/projects/" + projectId + "/directories/" + directoryId, HttpPatch.METHOD_NAME, "api/sourcefiles/editDirectory.json", "api/sourcefiles/directory.json"),
+                RequestMock.build(this.url + "/directories", HttpGet.METHOD_NAME, "api/sourcefiles/searchDirectories.json", new HashMap<String, Object>() {{
+                    put("filter", directoryName);
+                    put("userId", userId);
+                }}),
                 RequestMock.build(this.url + "/projects/" + projectId + "/files", HttpGet.METHOD_NAME, "api/sourcefiles/listFiles.json"),
                 RequestMock.build(this.url + "/projects/" + project3Id + "/files", HttpGet.METHOD_NAME, "api/sourcefiles/listFiles.json", new HashMap<String, String>() {{
                     put("orderBy", "id%20asc");
@@ -94,6 +109,10 @@ public class SourceFilesApiTest extends TestClient {
                 RequestMock.build(this.url + "/projects/" + projectId + "/files/" + fileId + "/preview", HttpGet.METHOD_NAME, "api/sourcefiles/downloadLink.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/files/" + fileId + "/revisions", HttpGet.METHOD_NAME, "api/sourcefiles/listFileRevisions.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/files/" + fileId + "/revisions/" + fileRevisionId, HttpGet.METHOD_NAME, "api/sourcefiles/fileRevision.json"),
+                RequestMock.build(this.url + "/files", HttpGet.METHOD_NAME, "api/sourcefiles/searchFiles.json", new HashMap<String, String>() {{
+                    put("filter", fileName);
+                    put("projectIds", projectIds);
+                }}),
                 RequestMock.build(String.format("%s/projects/%d/strings/reviewed-builds", this.url, projectId), HttpGet.METHOD_NAME, "api/sourcefiles/listReviewedSourceFileBuilds.json"),
                 RequestMock.build(String.format("%s/projects/%d/strings/reviewed-builds", url, projectId), HttpPost.METHOD_NAME, "api/sourcefiles/buildReviewedSourceFilesRequest.json", "api/sourcefiles/buildReviewedSourceFiles.json"),
                 RequestMock.build(String.format("%s/projects/%d/strings/reviewed-builds/%d", url, projectId, buildId), HttpGet.METHOD_NAME, "api/sourcefiles/checkReviewedSourceFilesBuildStatus.json"),
@@ -201,6 +220,20 @@ public class SourceFilesApiTest extends TestClient {
         ResponseObject<Branch> branchResponseObject = this.getSourceFilesApi().editBranch(projectId, branchId, Arrays.asList(request));
         assertEquals(branchResponseObject.getData().getId(), branchId);
         assertEquals(branchResponseObject.getData().getName(), branchName);
+    }
+
+    @Test
+    public void searchBranchesTest() {
+        ResponseList<Branch> branchResponseList = this.getSourceFilesApi().searchBranches(branchName, projectIds, null, null, null);
+
+        assertEquals(branchId, branchResponseList.getData().get(0).getData().getId());
+        assertEquals(project5Id, branchResponseList.getData().get(0).getData().getProjectId());
+        assertEquals(branchName, branchResponseList.getData().get(0).getData().getName());
+        assertEquals(branchTitle, branchResponseList.getData().get(0).getData().getTitle());
+        assertEquals(new Date(119,Calendar.SEPTEMBER,16,13,48,4), branchResponseList.getData().get(0).getData().getCreatedAt());
+        assertEquals(new Date(119,Calendar.SEPTEMBER,19,13,25,27), branchResponseList.getData().get(0).getData().getUpdatedAt());
+        assertEquals(exportPattern, branchResponseList.getData().get(0).getData().getExportPattern());
+        assertEquals(priority, branchResponseList.getData().get(0).getData().getPriority().name().toLowerCase());
     }
 
     @Test
@@ -335,6 +368,17 @@ public class SourceFilesApiTest extends TestClient {
         ResponseObject<Directory> directoryResponseObject = this.getSourceFilesApi().editDirectory(projectId, directoryId, Arrays.asList(request));
         assertEquals(directoryResponseObject.getData().getId(), directoryId);
         assertEquals(directoryResponseObject.getData().getName(), directoryName);
+    }
+
+    @Test
+    public void searchDirectoriesTest() {
+        ResponseList<Directory> directoryResponseList = this.getSourceFilesApi().searchDirectories(directoryName, null, userId, null, null);
+
+        assertEquals(directoryName, directoryResponseList.getData().get(0).getData().getName());
+        assertEquals(directoryTitle, directoryResponseList.getData().get(0).getData().getTitle());
+        assertEquals(project5Id, directoryResponseList.getData().get(0).getData().getProjectId());
+        assertEquals(new Date(119,Calendar.SEPTEMBER,19,14,14,0), directoryResponseList.getData().get(0).getData().getCreatedAt());
+        assertEquals(priority, directoryResponseList.getData().get(0).getData().getPriority().name().toLowerCase());
     }
 
     @Test
@@ -646,6 +690,17 @@ public class SourceFilesApiTest extends TestClient {
         assertNull(((DocxFileImportOptions) importOptions).getSrxStorageId());
     }
     //</editor-fold>
+
+    @Test
+    public void searchFilesTest() {
+        ResponseList<? extends FileInfo> fileInfoResponseList = this.getSourceFilesApi().searchFiles(fileName, projectIds, null, null, null);
+
+        assertEquals(fileName, fileInfoResponseList.getData().get(0).getData().getName());
+        assertEquals(branchId, fileInfoResponseList.getData().get(0).getData().getBranchId());
+        assertEquals(fileId, fileInfoResponseList.getData().get(0).getData().getId());
+        assertEquals(project5Id, fileInfoResponseList.getData().get(0).getData().getProjectId());
+
+    }
 
     @Test
     public void listAssetReferencesTest() {

--- a/src/test/java/com/crowdin/client/sourcestrings/SourceStringsApiTest.java
+++ b/src/test/java/com/crowdin/client/sourcestrings/SourceStringsApiTest.java
@@ -35,6 +35,8 @@ public class SourceStringsApiTest extends TestClient {
     private final Long storageId = 61L;
     private final Long labelId = 1L;
     private final String uploadId = "50fb3506-4127-4ba8-8296-f97dc7e3e0c3";
+    private final String scope = "all";
+    private final String projectIds = "1,2,3";
 
     @Override
     public List<RequestMock> getMocks() {
@@ -55,6 +57,10 @@ public class SourceStringsApiTest extends TestClient {
                 RequestMock.build(this.url + "/projects/" + projectId + "/strings/" + id, HttpGet.METHOD_NAME, "api/strings/string.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/strings/" + id, HttpDelete.METHOD_NAME),
                 RequestMock.build(this.url + "/projects/" + projectId + "/strings/" + id, HttpPatch.METHOD_NAME, "api/strings/editString.json", "api/strings/string.json"),
+                RequestMock.build(this.url + "/strings", HttpGet.METHOD_NAME, "api/strings/searchStrings.json", new HashMap<String, String>() {{
+                    put("filter", scope);
+                    put("projectIds", projectIds);
+                }}),
                 RequestMock.build(this.url + "/projects/" + projectId + "/strings", HttpPatch.METHOD_NAME, "api/strings/stringBatchOperationsRequest.json", "api/strings/listStrings.json"),
                 new RequestMock(this.url + "/projects/" + project2Id + "/strings/" + id, "api/strings/editString.json", "api/strings/string.json", HttpPatch.METHOD_NAME, singletonMap("updateOption", UpdateOption.KEEP_TRANSLATIONS_AND_APPROVALS), emptyMap()),
                 new RequestMock(this.url + "/projects/" + project2Id + "/strings", "api/strings/stringBatchOperationsRequest.json", "api/strings/listStrings.json", HttpPatch.METHOD_NAME, singletonMap("updateOption", UpdateOption.CLEAR_TRANSLATIONS_AND_APPROVALS), emptyMap())
@@ -340,6 +346,18 @@ public class SourceStringsApiTest extends TestClient {
                 .editSourceString(project2Id, id, singletonList(request), UpdateOption.KEEP_TRANSLATIONS_AND_APPROVALS);
         assertEquals(sourceStringResponseObject.getData().getId(), id);
         assertEquals(sourceStringResponseObject.getData().getText(), text);
+    }
+
+    @Test
+    public void searchStringsTest() {
+        ResponseList<SourceString> sourceStringResponseList = this.getSourceStringsApi().searchSourceStrings(scope, projectIds, null, null, null, null, null);
+
+        assertEquals(id, sourceStringResponseList.getData().get(0).getData().getId());
+        assertEquals(text, sourceStringResponseList.getData().get(0).getData().getText());
+        assertFalse(sourceStringResponseList.getData().get(0).getData().isIcu());
+        assertTrue(sourceStringResponseList.getData().get(0).getData().isDuplicate());
+        assertEquals(new Date(119,Calendar.SEPTEMBER,20,12,43,57), sourceStringResponseList.getData().get(0).getData().getCreatedAt());
+        assertEquals(new Date(119,Calendar.SEPTEMBER,20,13,24,01), sourceStringResponseList.getData().get(0).getData().getUpdatedAt());
     }
 
     @Test

--- a/src/test/java/com/crowdin/client/stringtranslations/StringTranslationsApiTest.java
+++ b/src/test/java/com/crowdin/client/stringtranslations/StringTranslationsApiTest.java
@@ -25,8 +25,10 @@ public class StringTranslationsApiTest extends TestClient {
     private final Long approval2Id = 190696L;
     private final Long translationId = 190694L;
     private final Long translation2Id = 190695L;
+    private final Long userId = 19L;
     private final String text = "Цю стрічку перекладено";
     private final String language = "uk";
+    private final String projectIds = "8,9,10";
     private final Long stringId = 35434L;
     private final Long string2Id = 35435L;
     private final Long voteId = 6643L;
@@ -70,6 +72,11 @@ public class StringTranslationsApiTest extends TestClient {
                 RequestMock.build(this.url + "/projects/" + projectId + "/translations/" + translationId, HttpGet.METHOD_NAME, "api/stringtranslations/translation.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/translations/" + translationId, HttpDelete.METHOD_NAME),
                 RequestMock.build(this.url + "/projects/" + projectId + "/translations/" + translationId, HttpPut.METHOD_NAME, "api/stringtranslations/translation.json"),
+                RequestMock.build(this.url + "/translations", HttpGet.METHOD_NAME, "api/stringtranslations/searchTranslations.json", new HashMap<String, String>() {{
+                    put("filter", text);
+                    put("projectIds", projectIds);
+                    put("languageIds", language);
+                }}),
                 RequestMock.build(this.url + "/projects/" + projectId + "/votes", HttpGet.METHOD_NAME, "api/stringtranslations/listVotes.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/votes", HttpPost.METHOD_NAME, "api/stringtranslations/addVoteRequest.json", "api/stringtranslations/vote.json"),
                 RequestMock.build(this.url + "/projects/" + projectId + "/votes/" + voteId, HttpGet.METHOD_NAME, "api/stringtranslations/vote.json"),
@@ -399,6 +406,17 @@ public class StringTranslationsApiTest extends TestClient {
     public void restoreTranslationTest() {
         ResponseObject<StringTranslation> stringTranslationResponseObject = this.getStringTranslationsApi().restoreStringTranslation(projectId, translationId);
         assertEquals(stringTranslationResponseObject.getData().getId(), translationId);
+    }
+
+    @Test
+    public void searchTranslationsTest() {
+        ResponseList<StringTranslation> stringTranslationResponseList = this.getStringTranslationsApi().searchTranslations(text, projectIds, null, language, null, null, null);
+
+        assertEquals(translation2Id, stringTranslationResponseList.getData().get(0).getData().getId());
+        assertEquals(text, stringTranslationResponseList.getData().get(0).getData().getText());
+        assertEquals(userId, stringTranslationResponseList.getData().get(0).getData().getUser().getId());
+        assertEquals(new Date(119, Calendar.SEPTEMBER, 23, 11, 26, 54), stringTranslationResponseList.getData().get(0).getData().getCreatedAt());
+        assertTrue(stringTranslationResponseList.getData().get(0).getData().getIsPreTranslated());
     }
 
 

--- a/src/test/resources/api/sourcefiles/searchBranches.json
+++ b/src/test/resources/api/sourcefiles/searchBranches.json
@@ -1,0 +1,20 @@
+{
+  "data": [
+    {
+      "data": {
+        "id": 34,
+        "projectId": 2,
+        "name": "develop-master",
+        "title": "Master branch",
+        "createdAt": "2019-09-16T13:48:04+00:00",
+        "updatedAt": "2019-09-19T13:25:27+00:00",
+        "exportPattern": "%three_letters_code%",
+        "priority": "normal"
+      }
+    }
+  ],
+  "pagination": {
+    "offset": 0,
+    "limit": 25
+  }
+}

--- a/src/test/resources/api/sourcefiles/searchDirectories.json
+++ b/src/test/resources/api/sourcefiles/searchDirectories.json
@@ -1,0 +1,23 @@
+{
+  "data": [
+    {
+      "data": {
+        "id": 4,
+        "projectId": 2,
+        "branchId": 34,
+        "directoryId": null,
+        "name": "main",
+        "title": "<Description materials>",
+        "exportPattern": "/localization/%locale%/%file_name%",
+        "path": "/main",
+        "priority": "normal",
+        "createdAt": "2019-09-19T14:14:00+00:00",
+        "updatedAt": "2019-09-19T14:14:00+00:00"
+      }
+    }
+  ],
+  "pagination": {
+    "offset": 0,
+    "limit": 25
+  }
+}

--- a/src/test/resources/api/sourcefiles/searchFiles.json
+++ b/src/test/resources/api/sourcefiles/searchFiles.json
@@ -1,0 +1,47 @@
+{
+  "data": [
+    {
+      "data": {
+        "id": 44,
+        "projectId": 2,
+        "branchId": 34,
+        "directoryId": 4,
+        "name": "umbrella_app.xliff",
+        "title": "source_app_info",
+        "context": "Context for translators",
+        "type": "xliff",
+        "path": "/directory1/directory2/filename.extension",
+        "status": "active",
+        "revisionId": 1,
+        "priority": "normal",
+        "importOptions": {
+          "importTranslations": false,
+          "firstLineContainsHeader": false,
+          "contentSegmentation": false,
+          "customSegmentation": false,
+          "scheme": {
+            "identifier": 0,
+            "sourcePhrase": 1,
+            "en": 2,
+            "de": 3
+          }
+        },
+        "exportOptions": {
+          "exportPattern": "/localization/%locale%/%file_name%.%file_extension%"
+        },
+        "excludedTargetLanguages": [
+          "en",
+          "es",
+          "pl"
+        ],
+        "parserVersion": 12,
+        "createdAt": "2019-09-19T15:10:43+00:00",
+        "updatedAt": "2019-09-19T15:10:46+00:00"
+      }
+    }
+  ],
+  "pagination": {
+    "offset": 0,
+    "limit": 25
+  }
+}

--- a/src/test/resources/api/strings/searchStrings.json
+++ b/src/test/resources/api/strings/searchStrings.json
@@ -1,0 +1,34 @@
+{
+  "data": [
+    {
+      "data": {
+        "id": 2814,
+        "projectId": 2,
+        "branchId": 12,
+        "identifier": "name",
+        "text": "Not all videos are shown to users. See more",
+        "type": "text",
+        "context": "shown on main page",
+        "maxLength": 35,
+        "isHidden": false,
+        "isDuplicate": true,
+        "masterStringId": 1,
+        "hasPlurals": false,
+        "isIcu": false,
+        "labelIds": [
+          3
+        ],
+        "webUrl": "https://example.crowdin.com/editor/1/all/en-pl?filter=basic&value=0&view=comfortable#2",
+        "createdAt": "2019-09-20T12:43:57+00:00",
+        "updatedAt": "2019-09-20T13:24:01+00:00",
+        "fileId": 48,
+        "directoryId": 13,
+        "revision": 1
+      }
+    }
+  ],
+  "pagination": {
+    "offset": 0,
+    "limit": 25
+  }
+}

--- a/src/test/resources/api/stringtranslations/searchTranslations.json
+++ b/src/test/resources/api/stringtranslations/searchTranslations.json
@@ -1,0 +1,31 @@
+{
+  "data": [
+    {
+      "data": {
+        "id": 190695,
+        "user": {
+          "id": 19,
+          "username": "john_doe",
+          "fullName": "John Smith",
+          "avatarUrl": ""
+        },
+        "rating": 10,
+        "createdAt": "2019-09-23T11:26:54+00:00",
+        "provider": "tm",
+        "providerId": 17,
+        "isPreTranslated": true,
+        "matchRate": 75,
+        "matchType": "fuzzy",
+        "text": "Цю стрічку перекладено",
+        "pluralCategoryName": "few",
+        "projectId": 8,
+        "stringId": 35,
+        "languageId": "uk"
+      }
+    }
+  ],
+  "pagination": {
+    "offset": 0,
+    "limit": 25
+  }
+}


### PR DESCRIPTION
This adds support for organization-level search API (closes: #389)

- Added `searchBranches`, `searchDirectories`, and `searchFiles` methods to `SourceFilesApi`;
- Added `searchSourceStrings` method to `SourceStringsApi`;
- Added `searchTranslations` method to `StringTranslationsApi`;
- Included organization-level search test cases and mock data.

