### PR TITLE
feat: add batch operations method for TM segments

### DIFF
--- a/src/main/java/com/crowdin/client/translationmemory/TranslationMemoryApi.java
+++ b/src/main/java/com/crowdin/client/translationmemory/TranslationMemoryApi.java
@@ -334,6 +334,21 @@ public class TranslationMemoryApi extends CrowdinApi {
         return ResponseObject.of(responseObject.getData());
     }
 
+    /**
+     * @param tmId translation memory identifier
+     * @param request request object
+     * @return  updated translation memory segment
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.tms.segments.patchBatch" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.tms.segments.patchBatch" target="_blank"><b>API Enterprise Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseList<TmSegment> batchOperationsTmSegment(Long tmId, List<PatchRequest> request) throws HttpException, HttpBadRequestException {
+        String url = formUrl_tmSegments(tmId);
+        TmSegmentResponseList responseList = this.httpClient.patch(url, request, new HttpRequestConfig(), TmSegmentResponseList.class);
+        return TmSegmentResponseList.to(responseList);
+    }
+
     //<editor-fold desc="Helper methods">
 
     private String formUrl_tmSegments(Long tmId) {

--- a/src/test/java/com/crowdin/client/translationmemory/TranslationMemorySegmentsApiTest.java
+++ b/src/test/java/com/crowdin/client/translationmemory/TranslationMemorySegmentsApiTest.java
@@ -24,9 +24,12 @@ public class TranslationMemorySegmentsApiTest extends TestClient {
     private final Long tm2Id = 2L;
     private final Long tm3Id = 3L;
     private final Long segmentId = 1L;
+    private final Long recordId = 1L;
 
     private final Long tmsId = 4L;
     private final Long tms2Id = 5L;
+
+    private final String recordText = "Перекладений текст 2";
 
     @Override
     public List<RequestMock> getMocks() {
@@ -89,6 +92,14 @@ public class TranslationMemorySegmentsApiTest extends TestClient {
                         HttpPatch.METHOD_NAME,
                         "api/translationmemory/segments/editTmSegmentRequest.json",
                         "api/translationmemory/segments/commonResponses_single.json"
+                ),
+
+                // BATCH OPERATIONS
+                RequestMock.build(
+                        formUrl_tmSegments(tmsId),
+                        HttpPatch.METHOD_NAME,
+                        "api/translationmemory/segments/batchTmSegmentRequest.json",
+                        "api/translationmemory/segments/batchTmSegmentResponse.json"
                 )
         );
     }
@@ -202,6 +213,46 @@ public class TranslationMemorySegmentsApiTest extends TestClient {
 
         ResponseObject<TmSegment> response = this.getTranslationMemoryApi().editTmSegment(tmId, segmentId, request);
         assertTmSegment(response.getData());
+    }
+
+    @Test
+    public void batchOperationsTmSegment() {
+        List<PatchRequest> request = new ArrayList<PatchRequest>() {{
+            add(new PatchRequest() {{
+                setOp(PatchOperation.ADD);
+                setPath("/-");
+                setValue(new CreateTmSegmentRequest() {{
+                    setRecords(singletonList(new TmSegmentRecordForm() {{
+                        setLanguageId("uk");
+                        setText("Перекладений текст");
+                    }}));
+                }});
+            }});
+            add(new PatchRequest() {{
+                setOp(PatchOperation.ADD);
+                setPath("/" + segmentId + "/records/-");
+                setValue(new TmSegmentRecordForm() {{
+                    setLanguageId("uk");
+                    setText("Перекладений текст");
+                }});
+            }});
+            add(new PatchRequest() {{
+                setOp(PatchOperation.REMOVE);
+                setPath("/" + segmentId);
+            }});
+            add(new PatchRequest() {{
+                setOp(PatchOperation.REMOVE);
+                setPath("/" + segmentId + "/records/" + recordId);
+            }});
+            add(new PatchRequest() {{
+                setOp(PatchOperation.REPLACE);
+                setPath("/" + segmentId + "/records/" + recordId + "/text");
+                setValue(recordText);
+            }});
+        }};
+
+        ResponseList<TmSegment> response = this.getTranslationMemoryApi().batchOperationsTmSegment(tmsId, request);
+        assertTmSegment(response.getData().get(0).getData());
     }
 
     @SneakyThrows

--- a/src/test/resources/api/translationmemory/segments/batchTmSegmentRequest.json
+++ b/src/test/resources/api/translationmemory/segments/batchTmSegmentRequest.json
@@ -1,0 +1,35 @@
+[
+  {
+    "op": "add",
+    "path": "/-",
+    "value": {
+      "records": [
+        {
+          "languageId": "uk",
+          "text": "Перекладений текст"
+        }
+      ]
+    }
+  },
+  {
+    "op": "add",
+    "path": "/1/records/-",
+    "value": {
+      "languageId": "uk",
+      "text": "Перекладений текст"
+    }
+  },
+  {
+    "op": "remove",
+    "path": "/1"
+  },
+  {
+    "op": "remove",
+    "path": "/1/records/1"
+  },
+  {
+    "op": "replace",
+    "path": "/1/records/1/text",
+    "value": "Перекладений текст 2"
+  }
+]

--- a/src/test/resources/api/translationmemory/segments/batchTmSegmentResponse.json
+++ b/src/test/resources/api/translationmemory/segments/batchTmSegmentResponse.json
@@ -1,0 +1,21 @@
+{
+  "data": [
+    {
+      "data": {
+        "id": 4,
+        "records": [
+          {
+            "id": 1,
+            "languageId": "uk",
+            "text": "Перекладений текст",
+            "usageCount": 13,
+            "createdBy": 1,
+            "updatedBy": 1,
+            "createdAt": "2019-09-16T13:48:04+00:00",
+            "updatedAt": "2019-09-16T13:48:04+00:00"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This adds support for TM Segment batch operations (closes: #388)

- added `batchOperationsTmSegment` method to `TranslationMemoryApi`;
- added unit tests for TM segment batch operations and mock data.