### PR TITLE
feat: add organization-level concordance search

### DIFF
--- a/src/main/java/com/crowdin/client/glossaries/GlossariesApi.java
+++ b/src/main/java/com/crowdin/client/glossaries/GlossariesApi.java
@@ -37,6 +37,20 @@ public class GlossariesApi extends CrowdinApi {
     }
 
     /**
+     * @param request request object
+     * @return list of search results
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.glossaries.concordance.post" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.glossaries.concordance.post" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseList<SearchConcordance> searchOrganizationConcordance(SearchOrganizationConcordanceRequest request) throws HttpException, HttpBadRequestException {
+        SearchConcordanceResponseList searchConcordanceResponseList =
+                this.httpClient.post(this.url + "/glossaries/concordance", request, new HttpRequestConfig(), SearchConcordanceResponseList.class);
+        return SearchConcordanceResponseList.of(searchConcordanceResponseList);
+    }
+
+    /**
      * @param glossaryId glossary identifier
      * @param limit maximum number of items to retrieve (default 25)
      * @param offset starting offset in the collection (default 0)

--- a/src/main/java/com/crowdin/client/glossaries/model/SearchOrganizationConcordanceRequest.java
+++ b/src/main/java/com/crowdin/client/glossaries/model/SearchOrganizationConcordanceRequest.java
@@ -1,0 +1,13 @@
+package com.crowdin.client.glossaries.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class SearchOrganizationConcordanceRequest {
+    private String sourceLanguageId;
+    private String targetLanguageId;
+    private List<String> expressions;
+    private Long userId;
+}

--- a/src/main/java/com/crowdin/client/translationmemory/TranslationMemoryApi.java
+++ b/src/main/java/com/crowdin/client/translationmemory/TranslationMemoryApi.java
@@ -11,6 +11,7 @@ import com.crowdin.client.translationmemory.model.SearchConcordance;
 import com.crowdin.client.translationmemory.model.SearchConcordanceRequest;
 import com.crowdin.client.translationmemory.model.SearchConcordanceResponse;
 import com.crowdin.client.translationmemory.model.SearchConcordanceResponseList;
+import com.crowdin.client.translationmemory.model.SearchOrganizationConcordanceRequest;
 import com.crowdin.client.translationmemory.model.TmSegment;
 import com.crowdin.client.translationmemory.model.TmSegmentResponseList;
 import com.crowdin.client.translationmemory.model.TmSegmentResponseObject;
@@ -49,6 +50,20 @@ public class TranslationMemoryApi extends CrowdinApi {
     public ResponseList<SearchConcordance> searchConcordance(Long projectId, SearchConcordanceRequest request) {
         String url = this.url + "/projects/" + projectId + "/tms/concordance";
         final SearchConcordanceResponseList searchConcordanceResponse = this.httpClient.post(url, request, new HttpRequestConfig(), SearchConcordanceResponseList.class);
+        return SearchConcordanceResponse.of(searchConcordanceResponse);
+    }
+
+    /**
+     * @param request request object
+     * @return list of search results
+     * @see <ul>
+     * <li><a href="https://developer.crowdin.com/api/v2/#operation/api.tms.concordance.post" target="_blank"><b>API Documentation</b></a></li>
+     * <li><a href="https://developer.crowdin.com/enterprise/api/v2/#operation/api.tms.concordance.post" target="_blank"><b>Enterprise API Documentation</b></a></li>
+     * </ul>
+     */
+    public ResponseList<SearchConcordance> searchOrganizationConcordance(SearchOrganizationConcordanceRequest request) throws HttpException, HttpBadRequestException {
+        String url = this.url + "/tms/concordance";
+        SearchConcordanceResponseList searchConcordanceResponse = this.httpClient.post(url, request, new HttpRequestConfig(), SearchConcordanceResponseList.class);
         return SearchConcordanceResponse.of(searchConcordanceResponse);
     }
 

--- a/src/main/java/com/crowdin/client/translationmemory/model/SearchOrganizationConcordanceRequest.java
+++ b/src/main/java/com/crowdin/client/translationmemory/model/SearchOrganizationConcordanceRequest.java
@@ -1,0 +1,15 @@
+package com.crowdin.client.translationmemory.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class SearchOrganizationConcordanceRequest {
+    private String sourceLanguageId;
+    private String targetLanguageId;
+    private Boolean autoSubstitution;
+    private Integer minRelevant;
+    private List<String> expressions;
+    private Long userId;
+}

--- a/src/test/java/com/crowdin/client/glossaries/GlossariesApiTest.java
+++ b/src/test/java/com/crowdin/client/glossaries/GlossariesApiTest.java
@@ -72,7 +72,8 @@ public class GlossariesApiTest extends TestClient {
                 RequestMock.build(this.url + "/glossaries/" + glossaryId + "/terms/" + termId, HttpGet.METHOD_NAME, "api/glossaries/term.json"),
                 RequestMock.build(this.url + "/glossaries/" + glossaryId + "/terms/" + termId, HttpDelete.METHOD_NAME),
                 RequestMock.build(this.url + "/glossaries/" + glossaryId + "/terms/" + termId, HttpPatch.METHOD_NAME, "api/glossaries/editTerm.json", "api/glossaries/term.json"),
-                RequestMock.build(this.url + "/projects/" + projectId + "/glossaries/concordance", HttpPost.METHOD_NAME, "api/glossaries/concordanceSearchRequest.json", "api/glossaries/concordanceSearchResponse.json")
+                RequestMock.build(this.url + "/projects/" + projectId + "/glossaries/concordance", HttpPost.METHOD_NAME, "api/glossaries/concordanceSearchRequest.json", "api/glossaries/concordanceSearchResponse.json"),
+                RequestMock.build(this.url + "/glossaries/concordance", HttpPost.METHOD_NAME, "api/glossaries/organizationConcordanceSearchRequest.json", "api/glossaries/concordanceSearchResponse.json")
         );
     }
 
@@ -88,6 +89,18 @@ public class GlossariesApiTest extends TestClient {
         assertEquals(searchConcordanceResponseList.getData().get(0).getData().getConcept().getId(), 3);
         assertEquals(searchConcordanceResponseList.getData().get(0).getData().getSourceTerms().get(0).getId(), termId);
         assertEquals(searchConcordanceResponseList.getData().get(0).getData().getTargetTerms().get(0).getId(), termId);
+    }
+
+    @Test
+    public void searchOrganizationConcordanceTest() {
+        SearchOrganizationConcordanceRequest request = new SearchOrganizationConcordanceRequest();
+        request.setSourceLanguageId("en");
+        request.setTargetLanguageId("de");
+        request.setExpressions(singletonList("Welcome!"));
+        request.setUserId(12L);
+        ResponseList<SearchConcordance> responseList = this.getGlossariesApi().searchOrganizationConcordance(request);
+        assertEquals(1, responseList.getData().size());
+        assertEquals(glossaryId, responseList.getData().get(0).getData().getGlossary().getId());
     }
 
     @Test

--- a/src/test/java/com/crowdin/client/translationmemory/TranslationMemoryApiTest.java
+++ b/src/test/java/com/crowdin/client/translationmemory/TranslationMemoryApiTest.java
@@ -10,6 +10,7 @@ import com.crowdin.client.framework.TestClient;
 import com.crowdin.client.translationmemory.model.AddTranslationMemoryRequest;
 import com.crowdin.client.translationmemory.model.SearchConcordance;
 import com.crowdin.client.translationmemory.model.SearchConcordanceRequest;
+import com.crowdin.client.translationmemory.model.SearchOrganizationConcordanceRequest;
 import com.crowdin.client.translationmemory.model.TranslationMemory;
 import com.crowdin.client.translationmemory.model.TranslationMemoryExportRequest;
 import com.crowdin.client.translationmemory.model.TranslationMemoryExportStatus;
@@ -54,7 +55,8 @@ public class TranslationMemoryApiTest extends TestClient {
                 RequestMock.build(this.url + "/tms/" + tmId + "/imports", HttpPost.METHOD_NAME, "api/translationmemory/importTm.json", "api/translationmemory/tmImportStatus.json"),
                 RequestMock.build(this.url + "/tms/" + tmId + "/imports/" + importId, HttpGet.METHOD_NAME, "api/translationmemory/tmImportStatus.json"),
                 RequestMock.build(String.format("%s/tms/%d/segments", this.url, tmId), HttpDelete.METHOD_NAME),
-                RequestMock.build(String.format("%s/projects/%d/tms/concordance", this.url, projectId), HttpPost.METHOD_NAME, "api/translationmemory/concordanceSearchRequest.json", "api/translationmemory/concordanceSearchResponse.json")
+                RequestMock.build(String.format("%s/projects/%d/tms/concordance", this.url, projectId), HttpPost.METHOD_NAME, "api/translationmemory/concordanceSearchRequest.json", "api/translationmemory/concordanceSearchResponse.json"),
+                RequestMock.build(this.url + "/tms/concordance", HttpPost.METHOD_NAME, "api/translationmemory/organizationConcordanceSearchRequest.json", "api/translationmemory/concordanceSearchResponse.json")
         );
     }
 
@@ -73,6 +75,20 @@ public class TranslationMemoryApiTest extends TestClient {
         assertEquals(searchConcordanceResponseList.getData().get(0).getData().getSource(), "Welcome!");
         assertEquals(searchConcordanceResponseList.getData().get(0).getData().getRelevant(), 100);
         assertEquals(searchConcordanceResponseList.getData().get(0).getData().getSubstituted(), "62→100");
+    }
+
+    @Test
+    public void searchOrganizationConcordanceTest() {
+        SearchOrganizationConcordanceRequest request = new SearchOrganizationConcordanceRequest();
+        request.setSourceLanguageId("en");
+        request.setTargetLanguageId("de");
+        request.setAutoSubstitution(true);
+        request.setMinRelevant(60);
+        request.setExpressions(singletonList("Welcome!"));
+        request.setUserId(12L);
+        ResponseList<SearchConcordance> responseList = this.getTranslationMemoryApi().searchOrganizationConcordance(request);
+        assertEquals(1, responseList.getData().size());
+        assertEquals(tmId, responseList.getData().get(0).getData().getTm().getId());
     }
 
     @Test

--- a/src/test/resources/api/glossaries/organizationConcordanceSearchRequest.json
+++ b/src/test/resources/api/glossaries/organizationConcordanceSearchRequest.json
@@ -1,0 +1,8 @@
+{
+  "sourceLanguageId": "en",
+  "targetLanguageId": "de",
+  "expressions": [
+    "Welcome!"
+  ],
+  "userId": 12
+}

--- a/src/test/resources/api/translationmemory/organizationConcordanceSearchRequest.json
+++ b/src/test/resources/api/translationmemory/organizationConcordanceSearchRequest.json
@@ -1,0 +1,10 @@
+{
+  "sourceLanguageId": "en",
+  "targetLanguageId": "de",
+  "autoSubstitution": true,
+  "minRelevant": 60,
+  "expressions": [
+    "Welcome!"
+  ],
+  "userId": 12
+}


### PR DESCRIPTION
## Summary

- add organization-level concordance search methods for glossaries and translation memories
- add dedicated request models with `expressions` and optional `userId`
- reuse the existing concordance response models while preserving the project-scoped APIs

## Why

Crowdin now exposes organization-scoped concordance endpoints that search across all accessible glossaries and translation memories.

## Testing

- `./gradlew build`

Closes #394